### PR TITLE
FIX Moved the --test argument in initscript; now it will only start one earlyoom process, not two!

### DIFF
--- a/earlyoom.initscript
+++ b/earlyoom.initscript
@@ -50,7 +50,7 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec /bin/bash --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec /bin/bash -- -c "$DAEMON $DAEMON_ARGS 2> \"$LOGFILE\"" \
+	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec /bin/bash -- -c "exec $DAEMON $DAEMON_ARGS 2> \"$LOGFILE\"" \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
 	# to handle requests from services started subsequently which depend


### PR DESCRIPTION
Oops!  When two of my processes were killed in one moment, I realised that the latest version of the initscript starts TWO `earlyoom` processes in parallel!

```
00:00:00     1 25506   0 root     /bin/bash -c /usr/local/bin/earlyoom  2> "/var/log/earlyoom.log" --test
00:00:00 25506 25510   0 root     /usr/local/bin/earlyoom
00:00:00     1 25511   0 root     /bin/bash -c /usr/local/bin/earlyoom  2> "/var/log/earlyoom.log"
00:00:00 25511 25512   0 root     /usr/local/bin/earlyoom
```

This was due to a misplaced `--test` argument, and was easily fixed.

I also fixed an omission with the "exec trick" so that the parent `bash` processes is not left running.
