### PR TITLE
Don't quit if no victim can be found; just report and return.

### DIFF
--- a/kill.c
+++ b/kill.c
@@ -121,7 +121,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj)
 	if(victim_pid == 0)
 	{
 		fprintf(stderr, "Error: Could not find a process to kill\n");
-		exit(9);
+		return;
 	}
 
 	name[0]=0;


### PR DESCRIPTION
 I don't know about you, but during system startup all my running processes have `oom_score == badness == 0`.

As a result, when the daemon is first started, it can't find any processes to kill, so it exits! ("Error: Could not find a process to kill")

- One solution is to start with an initial `victim_score = -9999`.
- Another is to return early if `sig == 0`.
- But the solution I offer in this PR is simply to `return` from the `userspace_kill` function if no victim is found, instead of exiting.

But you may want to consider applying the first solution as well. I could understand not wanting to kill processes with negative badness, but it's surely better to kill a process with badness `0` rather than do nothing at all (start with `victim_score = -1`).