### PR TITLE
rename GITVERSION to VERSION and don't override a given value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GITVERSION=\"$(shell git describe --tags --dirty)\"
-CFLAGS=-Wextra -DGITVERSION=$(GITVERSION) -g
+VERSION ?= $(shell git describe --tags --dirty)
+CFLAGS = -Wextra -DVERSION=\"$(VERSION)\" -g
 
 .PHONY: earlyoom
 earlyoom:

--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 	 * may lag behind stderr */
 	setlinebuf(stdout);
 
-	fprintf(stderr, "earlyoom %s\n", GITVERSION);
+	fprintf(stderr, "earlyoom %s\n", VERSION);
 
 	if(chdir("/proc")!=0)
 	{


### PR DESCRIPTION
With this change, package maintainers can specify the packaged version via the make call: `make VERSION=v0.9`.

I'm trying to package the github release tarballs, but currently I get errors because the source is not in a git repository.