### PR TITLE
Customize installprefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GITVERSION=\"$(shell git describe --tags --dirty)\"
-CFLAGS=-Wextra -DGITVERSION=$(GITVERSION) -g
+VERSION ?= $(shell git describe --tags --dirty)
+CFLAGS = -Wextra -DVERSION=\"$(VERSION)\" -g
 
 .PHONY: earlyoom
 earlyoom:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 VERSION ?= $(shell git describe --tags --dirty)
-CFLAGS = -Wextra -DVERSION=\"$(VERSION)\" -g
+CFLAGS   = -Wextra -DVERSION=\"$(VERSION)\" -g
+PREFIX  ?= "/usr/local"
+DESTDIR ?= ""
+TARGET   = $(DESTDIR)$(PREFIX)
 
 .PHONY: earlyoom
 earlyoom:
@@ -9,22 +12,21 @@ clean:
 	rm -f earlyoom
 
 install: earlyoom
-	cp earlyoom -f /usr/local/bin/earlyoom
-	cp earlyoom.service /etc/systemd/system/earlyoom.service
-	systemctl enable earlyoom
+	install -D -m 755 ./earlyoom "$(TARGET)/bin/earlyoom"
+	install -D -m 644 ./earlyoom.service "$(TARGET)/lib/systemd/system/earlyoom.service"
+	sed -i s~\$${PREFIX}~$(PREFIX)~g "$(TARGET)/lib/systemd/system/earlyoom.service"
 
 install-initscript: earlyoom
-	cp earlyoom -f /usr/local/bin/earlyoom
-	cp earlyoom.initscript /etc/init.d/earlyoom
-	chmod a+x /etc/init.d/earlyoom
+	cp earlyoom -f "$(TARGET)/bin/earlyoom"
+	cp earlyoom.initscript "$(DESTDIR)/etc/init.d/earlyoom"
+	chmod a+x "$(DESTDIR)/etc/init.d/earlyoom"
 	update-rc.d earlyoom start 18 2 3 4 5 . stop 20 0 1 6 .
 
 uninstall:
-	rm -f /usr/local/bin/earlyoom
-	systemctl disable earlyoom
-	rm -f /etc/systemd/system/earlyoom.service
+	rm -f "$(TARGET)/bin/earlyoom"
+	rm -f "$(TARGET)/lib/systemd/system/earlyoom.service"
 
 uninstall-initscript:
-	rm -f /usr/local/bin/earlyoom
-	rm -f /etc/init.d/earlyoom
+	rm -f "$(TARGET)/bin/earlyoom"
+	rm -f "$(DESTDIR)/etc/init.d/earlyoom"
 	update-rc.d earlyoom remove

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Easy:
 git clone https://github.com/rfjakob/earlyoom.git
 cd earlyoom
 make
-sudo make install # Optional, if you want earlyoom to start
-                  # automatically as a service (works on Fedora)
+sudo make install
+sudo systemctl enable earlyoom    # Optional, if you want earlyoom to start
+                                  # automatically as a systemd service
 ```
 
 Use

--- a/earlyoom.service
+++ b/earlyoom.service
@@ -1,7 +1,7 @@
 [Service]
 StandardOutput=null
 StandardError=syslog
-ExecStart=/usr/local/bin/earlyoom
+ExecStart=${PREFIX}/bin/earlyoom
 
 [Install]
 WantedBy=multi-user.target

--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 	 * may lag behind stderr */
 	setlinebuf(stdout);
 
-	fprintf(stderr, "earlyoom %s\n", GITVERSION);
+	fprintf(stderr, "earlyoom %s\n", VERSION);
 
 	if(chdir("/proc")!=0)
 	{


### PR DESCRIPTION
add support for `DESTDIR` and `PREFIX` to customize location and introduce staged builds. I tried to keep it as simple as possible.

With this change, this is what my packaging file now looks like:
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=earlyoom