### PR TITLE
Add -Waggregate-return to Makefile and fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell git describe --tags --dirty)
-CFLAGS = -Wall -Wextra -DVERSION=\"$(VERSION)\" -g
+CFLAGS = -Wall -Wextra -Waggregate-return -DVERSION=\"$(VERSION)\" -g
 
 .PHONY: earlyoom
 earlyoom:

--- a/main.c
+++ b/main.c
@@ -100,7 +100,8 @@ int main(int argc, char *argv[])
 		exit(2);
 	}
 
-	struct meminfo m = parse_meminfo();
+	struct meminfo m;
+	parse_meminfo(&m);
 	mem_min = m.MemTotal * mem_min_percent / 100;
 	swap_min = m.SwapTotal * swap_min_percent / 100;
 
@@ -120,7 +121,7 @@ int main(int argc, char *argv[])
 	c = 1; // Start at 1 so we do not print another status line immediately
 	while(1)
 	{
-		m = parse_meminfo();
+		parse_meminfo(&m);
 
 		if(c % 10 == 0)
 		{
@@ -142,9 +143,9 @@ int main(int argc, char *argv[])
 			handle_oom(procdir, 9, kernel_oom_killer, ignore_oom_score_adj);
 			oom_cnt++;
 		}
-		
+
 		usleep(100000); // 100ms
 	}
-	
+
 	return 0;
 }

--- a/meminfo.c
+++ b/meminfo.c
@@ -46,11 +46,12 @@ static long available_guesstimate(const char *buf) {
     return MemFree + Cached + Buffers - Shmem;
 }
 
-struct meminfo parse_meminfo() {
+void parse_meminfo(struct meminfo *pmi) {
 	static FILE* fd;
 	static char buf[8192];
     static int guesstimate_warned = 0;
-	struct meminfo m;
+
+	memset (pmi, 0, sizeof (struct meminfo));
 
 	if(fd == NULL)
 		fd = fopen("/proc/meminfo", "r");
@@ -67,13 +68,13 @@ struct meminfo parse_meminfo() {
 	}
 	buf[len] = 0; // Make sure buf is zero-terminated
 
-	m.MemTotal = get_entry_fatal("MemTotal:", buf);
-	m.SwapTotal = get_entry_fatal("SwapTotal:", buf);
-	m.SwapFree = get_entry_fatal("SwapFree:", buf);
+	pmi->MemTotal = get_entry_fatal("MemTotal:", buf);
+	pmi->SwapTotal = get_entry_fatal("SwapTotal:", buf);
+	pmi->SwapFree = get_entry_fatal("SwapFree:", buf);
 
-	m.MemAvailable = get_entry("MemAvailable:", buf);
-	if(m.MemAvailable == -1) {
-		m.MemAvailable = available_guesstimate(buf);
+	pmi->MemAvailable = get_entry("MemAvailable:", buf);
+	if(pmi->MemAvailable == -1) {
+		pmi->MemAvailable = available_guesstimate(buf);
         if(guesstimate_warned == 0) {
 			fprintf(stderr, "Warning: Your kernel does not provide MemAvailable data (needs 3.14+)\n"
 			                "         Falling back to guesstimate\n");
@@ -81,5 +82,5 @@ struct meminfo parse_meminfo() {
         }
     }
 
-	return m;
+	return;
 }

--- a/meminfo.h
+++ b/meminfo.h
@@ -6,4 +6,4 @@ struct meminfo {
 	/* -1 means no data available */
 };
 
-struct meminfo parse_meminfo();
+void parse_meminfo(struct meminfo * pmi);


### PR DESCRIPTION
Warn when a full struct is being returned by a function. Returning small
structs is generally ok, but returning larger structs is definitely not
a good idea. Instead, declare the struct locally and pass a pointer to
function that fills in the struct.