### PR TITLE
Fixed deamon not starting using initscript

### DIFF
--- a/earlyoom.initscript
+++ b/earlyoom.initscript
@@ -50,7 +50,7 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec /bin/bash --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec /bin/bash -- -c "exec $DAEMON $DAEMON_ARGS 2> \"$LOGFILE\"" \
+	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --startas /bin/bash -- -c "exec $DAEMON $DAEMON_ARGS 2> \"$LOGFILE\"" \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
 	# to handle requests from services started subsequently which depend


### PR DESCRIPTION
This PR fixes earlyoom not starting via initscript on Linux Mint with SysV 2.88dsf-41ubuntu6.3. The change is based on this SO answer: http://stackoverflow.com/a/21029952/5137879