### PR TITLE
Move master to tag v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ accept
 
 Changelog
 ---------
+* v0.11: Fix undefined behavoir in get_entry_fatal (missing return, [commit](https://github.com/rfjakob/earlyoom/commit/9251d25618946723eb8a829404ebf1a65d99dbb0))
 * v0.10: Allow to override Makefile's VERSION variable to make packaging easier,
   add `-v` command-line option
 * v0.9: If oom_score of all processes is 0, use VmRss to find a victim


### PR DESCRIPTION
Tag `v0.11` is not in the master branch. this commit  moves the master forward to the newest commit