### PR TITLE
Improve experience on servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcc as build
+
+WORKDIR /usr/src
+COPY . .
+
+ENV CFLAGS -static
+RUN make
+
+###
+
+FROM scratch
+COPY --from=build /usr/src/earlyoom /
+
+ENTRYPOINT ["/earlyoom"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell git describe --tags --dirty)
-CFLAGS = -Wall -Wextra -DVERSION=\"$(VERSION)\" -g
+CFLAGS += -Wall -Wextra -DVERSION=\"$(VERSION)\" -g
 
 .PHONY: earlyoom
 earlyoom:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Usage: earlyoom [-m PERCENT] [-s PERCENT] [-k|-i] [-h]
 -i ... user-space oom killer should ignore positive oom_score_adj values
 -d ... enable debugging messages
 -v ... print version information and exit
+-r ... memory report interval in seconds (default 1), set to 0 to disable completely
 -h ... this help text
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Usage: earlyoom [-m PERCENT] [-s PERCENT] [-k|-i] [-h]
 -d ... enable debugging messages
 -v ... print version information and exit
 -r ... memory report interval in seconds (default 1), set to 0 to disable completely
+-p ... set niceness of earlyoom to -20 and oom_score_adj to -1000
 -h ... this help text
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ earlyoom v0.10
 Usage: earlyoom [-m PERCENT] [-s PERCENT] [-k|-i] [-h]
 -m ... set available memory minimum to PERCENT of total (default 10 %)
 -s ... set free swap minimum to PERCENT of total (default 10 %)
+-M ... set available memory minimum to KiB
+-S ... set free swap minimum to KiB
 -k ... use kernel oom killer instead of own user-space implementation
 -i ... user-space oom killer should ignore positive oom_score_adj values
 -d ... enable debugging messages

--- a/main.c
+++ b/main.c
@@ -8,11 +8,14 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include "meminfo.h"
 #include "kill.h"
 
 int enable_debug = 0;
+int set_oom_score_adj (int oom_score_adj);
 
 int main(int argc, char *argv[])
 {
@@ -24,6 +27,7 @@ int main(int argc, char *argv[])
 	long mem_min = 0, swap_min = 0; /* Same thing in KiB */
 	int ignore_oom_score_adj = 0;
 	int report_interval = 1;
+	int set_my_priority = 0;
 
 	/* request line buffering for stdout - otherwise the output
 	 * may lag behind stderr */
@@ -49,7 +53,7 @@ int main(int argc, char *argv[])
 	}
 
 	int c;
-	while((c = getopt (argc, argv, "m:s:M:S:kidvr:h")) != -1)
+	while((c = getopt (argc, argv, "m:s:M:S:kidvr:ph")) != -1)
 	{
 		switch(c)
 		{
@@ -101,6 +105,9 @@ int main(int argc, char *argv[])
 					exit(15);
 				}
 				break;
+			case 'p':
+				set_my_priority = 1;
+				break;
 			case 'h':
 				fprintf(stderr,
 					"Usage: earlyoom [-m PERCENT] [-s PERCENT] [-k|-i] [-h]\n"
@@ -113,6 +120,7 @@ int main(int argc, char *argv[])
 					"-d ... enable debugging messages\n"
 					"-v ... print version information and exit\n"
 					"-r ... memory report interval in seconds (default 1), set to 0 to disable completely\n"
+					"-p ... set niceness of earlyoom to -20 and oom_score_adj to -1000\n"
 					"-h ... this help text\n");
 				exit(1);
 			case '?':
@@ -168,6 +176,14 @@ int main(int argc, char *argv[])
 	if(mlockall(MCL_CURRENT|MCL_FUTURE) !=0 )
 		perror("Could not lock memory - continuing anyway");
 
+	if (set_my_priority) {
+		if(setpriority(PRIO_PROCESS, 0, -20) !=0 )
+			perror("Could not set priority - continuing anyway");
+
+		if(set_oom_score_adj(-1000) !=0 )
+			perror("Could not set oom_score_adj to -1000 for earlyoom process - continuing anyway");
+	}
+
 	c = 1; // Start at 1 so we do not print another status line immediately
 	report_interval = report_interval * 10; // convert seconds to tenth of second
 	while(1)
@@ -198,5 +214,22 @@ int main(int argc, char *argv[])
 		usleep(100000); // 100ms
 	}
 	
+	return 0;
+}
+
+int set_oom_score_adj (int oom_score_adj)
+{
+	char buf[256];
+	pid_t pid = getpid();
+
+	snprintf(buf, sizeof(buf), "%d/oom_score_adj", pid);
+	FILE * f = fopen(buf, "w");
+	if(f == NULL) {
+		return -1;
+	}
+
+	fprintf(f, "%d", oom_score_adj);
+	fclose(f);
+
 	return 0;
 }


### PR DESCRIPTION
I've added some changes to improve earlyoom experience when running on servers.

1. Added Dockerfile (many people use docker to run stuff on servers)
2. As most servers have very large amount of RAM compared to desktop (64+ GiB), setting minimal memory value in percents of all RAM is not always a good idea, so I added options to set it in absolute value
3. Added `-r` option to control amount of stdout spam
4. Set maximum priority of earlyoom process
5. Set oom_score_adj to -1000 of earlyoom process on startup