### PR TITLE
Add support for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,31 @@ using
 systemctl status earlyoom
 ```
 
+### Notifications
+
+The command-line flag `-n` enables notifications via `notify-send`. However, if earlyoom is being
+run by a user other than the one running your desktop environment (e.g. if it's run as a service
+or cron job) then `notify-send` will not work on its own, as DBUS, X, and/or display information
+may required.
+
+In this case, you can use `-N` to supply environment variables or another command. The exact value
+will vary depending on your desktop environment, but the following command may work. `YOUR_USER`
+should be replaced with output of `whoami` and `YOUR_USER_ID` with output of `echo $UID`. Your
+`DISPLAY` value may also be different (check `echo $DISPLAY`).
+
+```bash
+earlyoom -N 'sudo -u YOUR_USER DISPLAY=:0 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/YOUR_USER_ID/bus notify-send'
+```
+
+Other options are discussed in [this thread](https://unix.stackexchange.com/questions/111188/using-notify-send-with-cron).
+
+Note that if you choose to use a command other than `notify-send`, it must support the same
+arguments. Example invocation earlyoom uses:
+
+```bash
+NOTIFY_COMMAND -i dialog-warning 'notif title' 'notif text'
+```
+
 Command line options
 --------------------
 ```
@@ -145,6 +170,8 @@ Usage: earlyoom [OPTION]...
   -S SIZE      set free swap minimum to SIZE KiB
   -k           use kernel oom killer instead of own user-space implementation
   -i           user-space oom killer should ignore positive oom_score_adj values
+  -n           enable notifications using "notify-send"
+  -N COMMAND   enable notifications using COMMAND
   -d           enable debugging messages
   -v           print version information and exit
   -r INTERVAL  memory report interval in seconds (default 1), set to 0 to

--- a/kill.c
+++ b/kill.c
@@ -43,12 +43,12 @@ static int isnumeric(char* str)
 
 static void maybe_notify(char* notif_command, char* notif_args)
 {
-	if(notif_command)
-	{
-		char notif[200 + sizeof notif_command];
-		snprintf(notif, 200 + sizeof notif_command, "%s %s", notif_command, notif_args);
-		system(notif);
-	}
+	if(!notif_command)
+		return;
+
+	char notif[600];
+	snprintf(notif, 600, "%s %s", notif_command, notif_args);
+	system(notif);
 }
 
 const char * const fopen_msg = "fopen %s failed: %s\n";
@@ -170,7 +170,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj, char
 	if(victim_pid == 0)
 	{
 		fprintf(stderr, "Error: Could not find a process to kill. Sleeping 10 seconds.\n");
-		maybe_notify(notif_command, "-i dialog-error 'EarlyOOM' 'Error: Could not find a process to kill'");
+		maybe_notify(notif_command, "-i dialog-error 'earlyoom' 'Error: Could not find a process to kill'");
 		sleep(10);
 		return;
 	}
@@ -186,7 +186,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj, char
 		fprintf(stderr, "Killing process %d %s\n", victim_pid, name);
 
 		char notif_args[200];
-		snprintf(notif_args, 200, "-i dialog-warning 'EarlyOOM' 'Killing process %d %s'", victim_pid, name);
+		snprintf(notif_args, 200, "-i dialog-warning 'earlyoom' 'Killing process %d %s'", victim_pid, name);
 		maybe_notify(notif_command, notif_args);
 	}
 
@@ -197,7 +197,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj, char
 		// In that case, trying again in 100ms will just yield the same error.
 		// Throttle ourselves to not spam the log.
 		fprintf(stderr, "Sleeping 10 seconds\n");
-		maybe_notify(notif_command, "-i dialog-error 'EarlyOOM' 'Error: Failed to kill process'");
+		maybe_notify(notif_command, "-i dialog-error 'earlyoom' 'Error: Failed to kill process'");
 		sleep(10);
 	}
 }
@@ -229,12 +229,12 @@ void trigger_kernel_oom(int sig, char *notif_command)
 	if(sig == 9)
 	{
 		fprintf(stderr, "Invoking oom killer: ");
-		maybe_notify(notif_command, "-i dialog-warning 'EarlyOOM' 'Invoking OOM killer'");
+		maybe_notify(notif_command, "-i dialog-warning 'earlyoom' 'Invoking OOM killer'");
 
 		if(fprintf(trig_fd, "f\n") != 2)
 		{
 			perror("failed");
-			maybe_notify(notif_command, "-i dialog-error 'EarlyOOM' 'Error: Failed to invoke OOM killer'");
+			maybe_notify(notif_command, "-i dialog-error 'earlyoom' 'Error: Failed to invoke OOM killer'");
 		}
 		else
 			fprintf(stderr, "done\n");

--- a/kill.c
+++ b/kill.c
@@ -41,6 +41,16 @@ static int isnumeric(char* str)
 	}
 }
 
+static void maybe_notify(char* notif_command, char* notif_args)
+{
+	if(notif_command)
+	{
+		char notif[200 + sizeof notif_command];
+		snprintf(notif, 200 + sizeof notif_command, "%s %s", notif_command, notif_args);
+		system(notif);
+	}
+}
+
 const char * const fopen_msg = "fopen %s failed: %s\n";
 
 /* Read /proc/pid/{oom_score, oom_score_adj, statm}
@@ -93,7 +103,7 @@ static struct procinfo get_process_stats(int pid)
  * Find the process with the largest oom_score and kill it.
  * See trigger_kernel_oom() for the reason why this is done in userspace.
  */
-static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj)
+static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj, char *notif_command)
 {
 	struct dirent * d;
 	char buf[256];
@@ -160,6 +170,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj)
 	if(victim_pid == 0)
 	{
 		fprintf(stderr, "Error: Could not find a process to kill. Sleeping 10 seconds.\n");
+		maybe_notify(notif_command, "-i dialog-error 'EarlyOOM' 'Error: Could not find a process to kill'");
 		sleep(10);
 		return;
 	}
@@ -171,7 +182,13 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj)
 	fclose(stat);
 
 	if(sig != 0)
+	{
 		fprintf(stderr, "Killing process %d %s\n", victim_pid, name);
+
+		char notif_args[200];
+		snprintf(notif_args, 200, "-i dialog-warning 'EarlyOOM' 'Killing process %d %s'", victim_pid, name);
+		maybe_notify(notif_command, notif_args);
+	}
 
 	if(kill(victim_pid, sig) != 0)
 	{
@@ -180,6 +197,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj)
 		// In that case, trying again in 100ms will just yield the same error.
 		// Throttle ourselves to not spam the log.
 		fprintf(stderr, "Sleeping 10 seconds\n");
+		maybe_notify(notif_command, "-i dialog-error 'EarlyOOM' 'Error: Failed to kill process'");
 		sleep(10);
 	}
 }
@@ -199,7 +217,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj)
  *    https://github.com/rfjakob/earlyoom/commit/f7e2cedce8e9605c688d0c6d7dc26b7e81817f02
  * Because of these issues, kill_by_rss() is used instead by default.
  */
-void trigger_kernel_oom(int sig)
+void trigger_kernel_oom(int sig, char *notif_command)
 {
 	FILE * trig_fd;
 	trig_fd = fopen("sysrq-trigger", "w");
@@ -211,18 +229,23 @@ void trigger_kernel_oom(int sig)
 	if(sig == 9)
 	{
 		fprintf(stderr, "Invoking oom killer: ");
+		maybe_notify(notif_command, "-i dialog-warning 'EarlyOOM' 'Invoking OOM killer'");
+
 		if(fprintf(trig_fd, "f\n") != 2)
+		{
 			perror("failed");
+			maybe_notify(notif_command, "-i dialog-error 'EarlyOOM' 'Error: Failed to invoke OOM killer'");
+		}
 		else
 			fprintf(stderr, "done\n");
 	}
 	fclose(trig_fd);
 }
 
-void handle_oom(DIR * procdir, int sig, int kernel_oom_killer, int ignore_oom_score_adj)
+void handle_oom(DIR * procdir, int sig, int kernel_oom_killer, int ignore_oom_score_adj, char *notif_command)
 {
 	if(kernel_oom_killer)
-		trigger_kernel_oom(sig);
+		trigger_kernel_oom(sig, notif_command);
 	else
-		userspace_kill(procdir, sig, ignore_oom_score_adj);
+		userspace_kill(procdir, sig, ignore_oom_score_adj, notif_command);
 }

--- a/kill.h
+++ b/kill.h
@@ -1,1 +1,1 @@
-void handle_oom(DIR *, int, int, int);
+void handle_oom(DIR *, int, int, int, char *);


### PR DESCRIPTION
This adds command line flags for sending notifications using `notify-send` or a custom command. Notifications are sent when a process is killed, kernel OOM killer is called, or there's an error. This was brought up in #19.

Apologies if anything is weirdly done, I have literally never written C before, so suggestions very welcome.