### PR TITLE
Adds an aggressive mode which ignores swap space

### DIFF
--- a/earlyoom.1
+++ b/earlyoom.1
@@ -59,6 +59,9 @@ print version information and exit
 .BI \-r " INTERVAL"
 memory report interval in seconds (default 1), set to 0 to disable completely
 .TP
+.B \-a
+makes the oom killer more aggressive by not considering swap usage
+.TP
 .B \-p
 set niceness of earlyoom to -20 and
 .I oom_score_adj

--- a/kill.c
+++ b/kill.c
@@ -181,6 +181,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj, char
 	fscanf(stat, "%*d %s", name);
 	fclose(stat);
 
+	fprintf(stderr, "Selected process %d %s\n", victim_pid, name);
 	if(sig != 0)
 	{
 		fprintf(stderr, "Killing process %d %s\n", victim_pid, name);

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ int main(int argc, char *argv[])
 	long mem_min = 0, swap_min = 0; /* Same thing in KiB */
 	int ignore_oom_score_adj = 0;
 	char *notif_command = NULL;
+	int aggressive_mode = 1;
 	int report_interval = 1;
 	int set_my_priority = 0;
 
@@ -50,7 +51,7 @@ int main(int argc, char *argv[])
 	}
 
 	int c;
-	while((c = getopt (argc, argv, "m:s:M:S:kinN:dvr:ph")) != -1)
+	while((c = getopt (argc, argv, "m:s:M:S:kinN:dvr:pah")) != -1)
 	{
 		switch(c)
 		{
@@ -98,6 +99,9 @@ int main(int argc, char *argv[])
 			case 'd':
 				enable_debug = 1;
 				break;
+			case 'a':
+				aggressive_mode = 1;
+				break;
 			case 'v':
 				// The version has already been printed above
 				exit(0);
@@ -128,6 +132,7 @@ int main(int argc, char *argv[])
 "  -r INTERVAL  memory report interval in seconds (default 1), set to 0 to\n"
 "               disable completely\n"
 "  -p           set niceness of earlyoom to -20 and oom_score_adj to -1000\n"
+"  -a           enable aggressive mode which doesn't factor in swap usage\n"
 "  -h           this help text\n");
 				exit(1);
 			case '?':
@@ -213,7 +218,8 @@ int main(int argc, char *argv[])
 		}
 		c++;
 
-		if(m.MemAvailable <= mem_min && m.SwapFree <= swap_min)
+		if( (m.MemAvailable <= mem_min && m.SwapFree <= swap_min) ||
+				(m.MemAvailable <= mem_min && aggressive_mode) )
 		{
 			fprintf(stderr, "Out of memory! avail: %lu MiB < min: %lu MiB\n",
 				m.MemAvailable / 1024, mem_min / 1024);


### PR DESCRIPTION
This is for only watching system memory by ignoring swap usage. This is especially beneficial for people like myself using a compressed zram block in addition to traditional storage.

Here is a little insight into my setup:
```
 free -m     
              total        used        free      shared  buff/cache   available
Mem:          32031        5748        4765        1754       21518       24064
Swap:         33055           1       33054

 swapon -s
Filename				Type		Size	Used	Priority
/dev/dm-1                              	partition	1048572	0	-2
/dev/loop2                             	partition	32800612	1548	1
```

**/dev/dm-1** is a traditional disk-partition for swap, but I also leverage systemd-swap for creating/enabling a zram/zswap memory space which is then added to in addition to the swap on disk but with a higher priority so the greedy nature of the Linux buffer cache won't use physical I/O for things like keeping inode lookups in memory after running `find` until the VM expires them.

```
 dmesg| ag swap
[    0.825467] zswap: loaded using pool lzo/zbud
[    8.049821] Adding 1048572k swap on /dev/mapper/arch-swap.  Priority:-2 extents:1 across:1048572k SSFS
[    9.536138] Adding 32800612k swap on /dev/loop2.  Priority:1 extents:1 across:32800612k DscFS
```

Anyway, I made this since I have other use-cases for my swap setup and didn't want this to interfere.

Thanks!