### PR TITLE
Tl/calculate process weight

### DIFF
--- a/earlyoom.1
+++ b/earlyoom.1
@@ -59,6 +59,9 @@ print version information and exit
 .BI \-r " INTERVAL"
 memory report interval in seconds (default 1), set to 0 to disable completely
 .TP
+.B \-a
+makes the oom killer more aggressive by not considering swap usage
+.TP
 .B \-p
 set niceness of earlyoom to -20 and
 .I oom_score_adj

--- a/kill.c
+++ b/kill.c
@@ -181,6 +181,7 @@ static void userspace_kill(DIR *procdir, int sig, int ignore_oom_score_adj, char
 	fscanf(stat, "%*d %s", name);
 	fclose(stat);
 
+	fprintf(stderr, "Selected process %d %s\n", victim_pid, name);
 	if(sig != 0)
 	{
 		fprintf(stderr, "Killing process %d %s\n", victim_pid, name);

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ int main(int argc, char *argv[])
 	long mem_min = 0, swap_min = 0; /* Same thing in KiB */
 	int ignore_oom_score_adj = 0;
 	char *notif_command = NULL;
+	int aggressive_mode = 1;
 	int report_interval = 1;
 	int set_my_priority = 0;
 
@@ -50,7 +51,7 @@ int main(int argc, char *argv[])
 	}
 
 	int c;
-	while((c = getopt (argc, argv, "m:s:M:S:kinN:dvr:ph")) != -1)
+	while((c = getopt (argc, argv, "m:s:M:S:kinN:dvr:pah")) != -1)
 	{
 		switch(c)
 		{
@@ -98,6 +99,9 @@ int main(int argc, char *argv[])
 			case 'd':
 				enable_debug = 1;
 				break;
+			case 'a':
+				aggressive_mode = 1;
+				break;
 			case 'v':
 				// The version has already been printed above
 				exit(0);
@@ -128,6 +132,7 @@ int main(int argc, char *argv[])
 "  -r INTERVAL  memory report interval in seconds (default 1), set to 0 to\n"
 "               disable completely\n"
 "  -p           set niceness of earlyoom to -20 and oom_score_adj to -1000\n"
+"  -a           enable aggressive mode which doesn't factor in swap usage\n"
 "  -h           this help text\n");
 				exit(1);
 			case '?':
@@ -213,7 +218,8 @@ int main(int argc, char *argv[])
 		}
 		c++;
 
-		if(m.MemAvailable <= mem_min && m.SwapFree <= swap_min)
+		if( (m.MemAvailable <= mem_min && m.SwapFree <= swap_min) ||
+				(m.MemAvailable <= mem_min && aggressive_mode) )
 		{
 			fprintf(stderr, "Out of memory! avail: %lu MiB < min: %lu MiB\n",
 				m.MemAvailable / 1024, mem_min / 1024);


### PR DESCRIPTION
Not sure if this would be interesting to you, but its a rough attempt at weighing a pid's total resident memory size in congruence with the amount of time it's been running. The idea here is to attempt to find some of the lower-hanging targets and avoid things like kernel daemons (which run at boot and generally don't use much memory).

[Here is a gist of the differences](https://gist.github.com/tonylambiris/dee9eb98f4bb30a3956e03cbc984d672)

As you can see in weighted mode it targeted more of the "interactive" applications on my system like chrome and all the gnome stuff as opposed to non-weighted in which processes like ksoftirqd and kworker are included in the process gathering.

Here's a quick overview of the difference regarding total process count:
```
  417 pids.noweight
  166 pids.weight
```

You may find this useful, or maybe not. Do as you wish with the PR. :+1: 