### PR TITLE
README: Update Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,9 @@ sudo dnf install earlyoom
 sudo systemctl enable --now earlyoom
 ```
 
-For Arch Linux, there's an [AUR package](https://aur.archlinux.org/packages/earlyoom/).
-Use your favorite AUR helper. For example:
+For Arch Linux, there's an [Arch Linux package](https://www.archlinux.org/packages/community/x86_64/earlyoom/):
 ```bash
-yay -S earlyoom
+sudo pacman -S earlyoom
 sudo systemctl enable --now earlyoom
 ```
 


### PR DESCRIPTION
earlyoom package was moved to Arch Linux official community repository.
we don't have to use AUR helper anymore.

https://www.archlinux.org/packages/community/x86_64/earlyoom/