### PR TITLE
Better meminfo.c IO error handling

### DIFF
--- a/meminfo.c
+++ b/meminfo.c
@@ -127,9 +127,10 @@ bool is_alive(int pid)
     // 10751 (cat) R 2663 10751 2663[...]
     char state;
     int res = fscanf(f, "%*d %*s %c", &state);
+    int fscanf_errno = errno;
     fclose(f);
     if (res < 1) {
-        warn("is_alive: fscanf() failed: %s\n", strerror(errno));
+        warn("is_alive: fscanf() failed: %s\n", strerror(fscanf_errno));
         return false;
     }
     debug("process state: %c\n", state);

--- a/meminfo.c
+++ b/meminfo.c
@@ -28,8 +28,9 @@ static long long get_entry(const char* name, const char* buf)
     errno = 0;
     long long val = strtoll(hit + strlen(name), NULL, 10);
     if (errno != 0) {
+        int strtoll_errno = errno;
         perror("get_entry: strtol() failed");
-        return -errno;
+        return -strtoll_errno;
     }
     return val;
 }


### PR DESCRIPTION
Fixes #189 and also a couple other things that I found, especially in relation to `errno` handling.

I recommend to review them per-commit.

Please review/test them well as I haven't managed to run the test suite yet.