### PR TITLE
Fix earlyoom killing processes too early when ZFS is in use

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -140,6 +140,12 @@ this help text
 
 105: Could not convert number when parse the contents of /proc/meminfo
 
+106: Could not open /proc/spl/kstat/zfs/arcstats despite it existing
+
+107: Could read /proc/spl/kstat/zfs/arcstats
+
+108: Could not parse /proc/spl/kstat/zfs/arcstats contents
+
 # Why not trigger the kernel oom killer?
 
 Earlyoom does not use `echo f > /proc/sysrq-trigger` because the Chrome people


### PR DESCRIPTION
* [x] Based on top of #190, please merge that first.

---

The ZFS ARC cache is memory-reclaimable, like the Linux buffer cache. However, in contrast to the buffer cache, it currently does not count to `MemAvailable` (see https://github.com/openzfs/zfs/issues/10255), leading earlyoom to believe we are out of memory when we still have a lot of memory available (in practice, many GBs).

Thus, until now, earlyoom tended to kill processes on ZFS systems even though there was no memory pressure.

This commit fixes it by adding the `size` field of `/proc/spl/kstat/zfs/arcstats` to `MemAvailable`.

The effect can be checked easily on ZFS systems:

Before this commit, dropping the ARC via (command from [1])

    echo 3 | sudo tee /proc/sys/vm/drop_caches

would result in an increase of free memory in earlyoom's output; with this fix, it stays equal.

[1]: https://serverfault.com/a/857386/128321
