### PR TITLE
Don't embedd timestamp in gzip'd man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 
 earlyoom.1.gz: earlyoom.1
 ifdef PANDOC
-	gzip -f -k $<
+	gzip -f -k -n $<
 endif
 
 uninstall: uninstall-bin uninstall-man


### PR DESCRIPTION
To make earlyoom reproducible pass the -n option to not save the
filename and timestamp in the gzip header.

Motivation: https://reproducible-builds.org/