### PR TITLE
remove dependency on c99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell git describe --tags --dirty 2> /dev/null)
-CFLAGS += -Wall -Wextra -Wformat-security -Wconversion -DVERSION=\"$(VERSION)\" -g -fstack-protector-all -std=gnu99
+CFLAGS += -Wall -Wextra -Wformat-security -Wconversion -DVERSION=\"$(VERSION)\" -g -fstack-protector-all
 
 DESTDIR ?=
 PREFIX ?= /usr/local

--- a/kill.c
+++ b/kill.c
@@ -81,7 +81,8 @@ int kill_wait(const poll_loop_args_t* args, pid_t pid, int sig)
     if (sig == 0) {
         return 0;
     }
-    for (unsigned i = 0; i < 100; i++) {
+    unsigned i;
+    for (i = 0; i < 100; i++) {
         float secs = (float)(i * poll_ms) / 1000;
         // We have sent SIGTERM but now have dropped below SIGKILL limits.
         // Escalate to SIGKILL.


### PR DESCRIPTION
This C dialect option is specified for a single for loop initial declaration. Remove it to allow compilation without C99 support.
