### PR TITLE
remove usleep for nanosleep

### DIFF
--- a/kill.c
+++ b/kill.c
@@ -105,7 +105,8 @@ int kill_wait(const poll_loop_args_t* args, pid_t pid, int sig)
             warn("process exited after %.1f seconds\n", secs);
             return 0;
         }
-        usleep(poll_ms * 1000);
+        struct timespec req = { .tv_sec = (time_t)(poll_ms / 1000), .tv_nsec = (poll_ms % 1000) * 1000000 };
+        nanosleep(&req, NULL);
     }
     errno = ETIME;
     return -1;

--- a/main.c
+++ b/main.c
@@ -12,6 +12,7 @@
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "globals.h"
@@ -405,7 +406,8 @@ static void poll_loop(const poll_loop_args_t* args)
         }
         unsigned sleep_ms = sleep_time_ms(args, &m);
         debug("adaptive sleep time: %d ms\n", sleep_ms);
-        usleep(sleep_ms * 1000);
+        struct timespec req = { .tv_sec = (time_t)(sleep_ms / 1000), .tv_nsec = (sleep_ms % 1000) * 1000000 };
+        nanosleep(&req, NULL);
         report_countdown_ms -= (int)sleep_ms;
     }
 }


### PR DESCRIPTION
usleep is considered obsolete and should be removed.

Made a patch that replaces usleep with nanosleep, but not sure if this is the most ideal approach, there's the issue with nanosleep and signal handlers interrupting the sleeping, but has work arounds, and also other methods like setitimer that could be used instead