### PR TITLE
Add CAP_SYS_NICE and CAP_SYS_RESOURCE capabilities

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -8,7 +8,7 @@ ExecStart=:TARGET:/earlyoom $EARLYOOM_ARGS
 # Run as an unprivileged user with random user id
 DynamicUser=true
 # Allow killing processes and calling mlockall()
-AmbientCapabilities=CAP_KILL CAP_IPC_LOCK
+AmbientCapabilities=CAP_KILL CAP_IPC_LOCK CAP_SYS_NICE CAP_SYS_RESOURCE
 # We don't need write access anywhere
 ProtectSystem=strict
 # We don't need /home at all, make it inaccessible


### PR DESCRIPTION
These capabilities are required for `-p` to work properly. Otherwise, it always gives an error saying "permission denied".