### PR TITLE
Log all processes, not just the victim

### DIFF
--- a/msg.c
+++ b/msg.c
@@ -55,6 +55,17 @@ int warn(const char* fmt, ...)
     return 0;
 }
 
+// Print a white informational message to stdout. No prefix is added.
+int info(const char* fmt, ...)
+{
+    const char* white = "\033[37m";
+    va_list vl;
+    va_start(vl, fmt);
+    color_log(stdout, white, fmt, vl);
+    va_end(vl);
+    return 0;
+}
+
 // Print a gray debug message to stdout. No prefix is added.
 int debug(const char* fmt, ...)
 {

--- a/msg.h
+++ b/msg.h
@@ -15,6 +15,7 @@
  */
 int fatal(int code, char* fmt, ...) __attribute__((noreturn, format(printf, 2, 3)));
 int warn(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+int info(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 int debug(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 
 typedef struct {


### PR DESCRIPTION
When selecting a process to kill, print a line for every process instead of
just the selected victim. This follows the behavior of the kernel OOM killer,
which logs a similar whole-system snapshot of memory usage when invoked.