### PR TITLE
Fix: print positive PGID instead of negative

### DIFF
--- a/kill.c
+++ b/kill.c
@@ -79,7 +79,7 @@ int kill_wait(const poll_loop_args_t* args, pid_t pid, int sig)
             return res;
         }
         pid = -res;
-        warn("killing whole process group %d (-g flag is active)\n", pid);
+        warn("killing whole process group %d (-g flag is active)\n", res);
     }
     int res = kill(pid, sig);
     if (res != 0) {


### PR DESCRIPTION
`pid` is the negative PGID due to the requirement of `kill()`.
Print the positive one instead.