### PR TITLE
Implement programmatic notifications

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -108,6 +108,19 @@ To actually see the notifications in your GUI session, you need to have
 [systembus-notify](https://github.com/rfjakob/systembus-notify)
 running as your user.
 
+#### -N SCRIPT
+Run the given script for each process killed.
+
+Within the script, information about the killed process can be obtained via the
+following environment variables:
+
+    EARLYOOM_PID     Process PID
+    EARLYOOM_NAME    Process name/path
+    EARLYOOM_UID     UID of the user running the process
+
+Warning: In case of dryrun mode, the script will be executed in rapid
+succession, ensure you have some sort of rate-limit implemented.
+
 #### -g
 Kill all processes that have same process group id (PGID) as the process
 with excessive memory usage.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ To actually see the notifications in your GUI session, you need to have
 [systembus-notify](https://github.com/rfjakob/systembus-notify)
 running as your user.
 
+Additionally, earlyoom can execute a script for each process killed, providing
+information about the process via the `EARLYOOM_PID`, `EARLYOOM_UID` and
+`EARLYOOM_NAME` environment variables. Pass `-N /path/to/script` to enable.
+
+Warning: In case of dryrun mode, the script will be executed in rapid
+succession, ensure you have some sort of rate-limit implemented.
+
 ### Preferred Processes
 
 The command-line flag `--prefer` specifies processes to prefer killing;

--- a/kill.c
+++ b/kill.c
@@ -69,14 +69,14 @@ static void notify_ext(const char* script, const procinfo_t victim)
     pid_t pid1 = fork();
 
     if (pid1 == -1) {
-        warn("fork() returned -1: %s\n", strerror(errno));
+        warn("notify_ext: fork() returned -1: %s\n", strerror(errno));
         return;
     } else if (pid1 != 0) {
         return;
     }
 
-    char pid_str[UID_BUFSIZ];
-    char uid_str[UID_BUFSIZ];
+    char pid_str[UID_BUFSIZ] = {0};
+    char uid_str[UID_BUFSIZ] = {0};
 
     snprintf(pid_str, UID_BUFSIZ, "%d", victim.pid);
     snprintf(uid_str, UID_BUFSIZ, "%d", victim.uid);

--- a/kill.h
+++ b/kill.h
@@ -16,6 +16,8 @@ typedef struct {
     double swap_kill_percent;
     /* send d-bus notifications? */
     bool notify;
+    /* Path to script for programmatic notifications (or NULL) */
+    char *notify_ext;
     /* kill all processes within a process group */
     bool kill_process_group;
     /* prefer/avoid killing these processes. NULL = no-op. */

--- a/main.c
+++ b/main.c
@@ -219,7 +219,7 @@ int main(int argc, char* argv[])
                 "  -M SIZE[,KILL_SIZE]       set available memory minimum to SIZE KiB\n"
                 "  -S SIZE[,KILL_SIZE]       set free swap minimum to SIZE KiB\n"
                 "  -n                        enable d-bus notifications\n"
-                "  -N                        enable programmatic notifications\n"
+                "  -N SCRIPT                 enable programmatic notifications\n"
                 "  -g                        kill all processes within a process group\n"
                 "  -d                        enable debugging messages\n"
                 "  -v                        print version information and exit\n"

--- a/main.c
+++ b/main.c
@@ -176,8 +176,7 @@ int main(int argc, char* argv[])
             args.kill_process_group = true;
             break;
         case 'N':
-            args.notify = true;
-            fprintf(stderr, "Notifying through D-Bus, argument '%s' ignored for compatability\n", optarg);
+            args.notify_ext = optarg;
             break;
         case 'd':
             enable_debug = 1;
@@ -220,6 +219,7 @@ int main(int argc, char* argv[])
                 "  -M SIZE[,KILL_SIZE]       set available memory minimum to SIZE KiB\n"
                 "  -S SIZE[,KILL_SIZE]       set free swap minimum to SIZE KiB\n"
                 "  -n                        enable d-bus notifications\n"
+                "  -N                        enable programmatic notifications\n"
                 "  -g                        kill all processes within a process group\n"
                 "  -d                        enable debugging messages\n"
                 "  -v                        print version information and exit\n"


### PR DESCRIPTION
Add support for running a script for each process killed (or would kill
in dryrun mode).

Fixes #254

> Warning: In case of dryrun mode, the script will be executed in rapid
succession, ensure you have some sort of rate-limit implemented.

I can attest no user mailboxes were harmed in the creation of this PR :)


I'll also check if I can get a couple of contrib/ examples cleaned up and generalized as ready-to-use examples in a later PR.