### PR TITLE
Option to ignore proccesses matching a regex

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -149,6 +149,15 @@ prefer killing processes matching REGEX (adds 300 to oom_score)
 #### \-\-avoid REGEX
 avoid killing processes matching REGEX (subtracts 300 from oom_score)
 
+#### \-\-ignore REGEX
+ignore processes matching REGEX.
+
+Unlike the \-\-avoid option, this option disables any potential killing of the matched processes
+that might have occurred due to the processes attaining a high oom_score.
+
+Use this option with caution as other processes might be sacrificed in place of the ignored
+processes when earlyoom determines to kill processes.
+
 #### \-\-dryrun
 dry run (do not kill any processes)
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Usage: ./earlyoom [OPTION]...
                             -100
   --prefer REGEX            prefer to kill processes matching REGEX
   --avoid REGEX             avoid killing processes matching REGEX
+  --ignore REGEX            ignore processes matching REGEX
   --dryrun                  dry run (do not kill any processes)
   -h, --help                this help text
 ```

--- a/kill.c
+++ b/kill.c
@@ -231,7 +231,7 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
         cur->badness = res;
     }
 
-    if ((args->prefer_regex || args->avoid_regex)) {
+    if ((args->prefer_regex || args->avoid_regex || args->ignore_regex)) {
         int res = get_comm(cur->pid, cur->name, sizeof(cur->name));
         if (res < 0) {
             debug("pid %d: error reading process name: %s\n", cur->pid, strerror(-res));
@@ -242,6 +242,9 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
         }
         if (args->avoid_regex && regexec(args->avoid_regex, cur->name, (size_t)0, NULL, 0) == 0) {
             cur->badness += BADNESS_AVOID;
+        }
+        if (args->ignore_regex && regexec(args->ignore_regex, cur->name, (size_t)0, NULL, 0) == 0) {
+            return false;
         }
     }
 
@@ -388,7 +391,7 @@ procinfo_t find_largest_process(const poll_loop_args_t* args)
     if (victim.pid == getpid()) {
         warn("%s: selected myself (pid %d). Do you use hidpid? See https://github.com/rfjakob/earlyoom/wiki/proc-hidepid\n",
             __func__, victim.pid);
-        // zeroize victim struct
+        // zero victim struct
         victim = (const procinfo_t) { 0 };
     }
 

--- a/kill.h
+++ b/kill.h
@@ -23,6 +23,8 @@ typedef struct {
     /* prefer/avoid killing these processes. NULL = no-op. */
     regex_t* prefer_regex;
     regex_t* avoid_regex;
+    /* will ignore these processes. NULL = no-op. */
+    regex_t* ignore_regex;
     /* memory report interval, in milliseconds */
     int report_interval_ms;
     /* Flag --dryrun was passed */


### PR DESCRIPTION
Hello, 
I have a usecase where I need a guaranty that certain processes will not be killed by earlyoom, hence I have created this pull request.
The PR adds a `--ignore` option that acts like the `--avoid` option, but instead of just decreasing the badness score of the matched process(es), it makes it so that the kill consideration of the matched process is skipped; thus always sparing the matched process(es). 