### PR TITLE
earlyoom.default: set prefer and avoid list

### DIFF
--- a/earlyoom.default
+++ b/earlyoom.default
@@ -2,7 +2,7 @@
 # /etc/init.d/earlyoom or by systemd from earlyoom.service.
 
 # Options to pass to earlyoom
-EARLYOOM_ARGS="-r 3600"
+EARLYOOM_ARGS="-r 3600 --prefer '^(Web Content|Isolated Web Co)$' --avoid '^(gnome-shell|gnome-session-c|gnome-session-b|lightdm|sddm|sddm-helper|gdm|gdm-wayland-ses|gdm-session-wor|gdm-x-session|Xorg|Xwayland|systemd|systemd-logind|dbus-daemon|dbus-broker|cinnamon|cinnamon-sessio|kwin_x11|kwin_wayland|plasmashell|ksmserver|plasma_session|startplasma-way|xfce4-session|mate-session|marco|lxqt-session|openbox|cryptsetup)$'"
 
 # Examples:
 


### PR DESCRIPTION
Stolen from Fedora, killing these programs will easily mess up your desktop
environment.

Source: https://pagure.io/fedora-workstation/issue/119
Downstream issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012870