### PR TITLE
Ignore SIGCHLD to prevent creating zombies

### DIFF
--- a/main.c
+++ b/main.c
@@ -58,12 +58,6 @@ double min(double x, double y)
     return y;
 }
 
-void handle_sigchld(int sig)
-{
-    (void)sig; // unused
-    waitpid(-1, NULL, WNOHANG);
-}
-
 // Dry-run oom kill to make sure that
 // (1) it works (meaning /proc is accessible)
 // (2) the stack grows to maximum size before calling mlockall()
@@ -107,7 +101,7 @@ int main(int argc, char* argv[])
     setlinebuf(stdout);
 
     /* clean up dbus-send zombies */
-    signal(SIGCHLD, handle_sigchld);
+    signal(SIGCHLD, SIG_IGN);
 
     fprintf(stderr, "earlyoom " VERSION "\n");
 


### PR DESCRIPTION
As https://github.com/rfjakob/earlyoom/issues/200#issuecomment-660024528 pointed out, calling `waitpid` once on SIGCHLD is not enough. Multiple children may died during the delivery of the signal.  I also hit this in production with earlyoom 1.7.

This PR uses `signal(SIGCHLD, SIG_IGN);` to prevents creations of zombies.
In manual sigaction(2),
> POSIX.1-1990 disallowed setting the action for SIGCHLD to SIG_IGN.
> POSIX.1-2001 and later allow this possibility, so that ignoring SIGCHLD
> can be used to prevent the creation of zombies (see wait(2)).

I think relying on POSIX 2001 should be enough for us. But note that ignoring SIGCHLD seems also prevent any usage of `wait*` functions. Currently we doesn't do it. Alternatively, we could run a loop in the signal handler to achieve the same goal.

Here is the test which proves a single `waitpid` is not enough,
```c
#include <stdio.h>
#include <sys/wait.h>
#include <unistd.h>
#include <spawn.h>

void handler(int _sig) {
    waitpid(-1, NULL, WNOHANG);
}

int main() {
    /* This still makes some zombies. The actual number of zombies may varies. */
    signal(SIGCHLD, handler);
    /* This creates no zombies always. */
    /* signal(SIGCHLD, SIG_IGN); */

    char *args[] = { "true", NULL };
    for (int i = 0; i < 128; ++i)
        posix_spawnp(NULL, args[0], NULL, NULL, args, NULL);

    puts("spawned");
    for(;;)
        sleep(1);
}
```
