### PR TITLE
Better support for ancient kernels

### DIFF
--- a/main.c
+++ b/main.c
@@ -109,11 +109,13 @@ int main(int argc, char* argv[])
         fatal(4, "Could not cd to /proc: %s", strerror(errno));
     }
 
+#ifdef PR_CAP_AMBIENT
     // When systemd starts a daemon with capabilities, it uses ambient
     // capabilities to do so. If not dropped, the capabilities can spread
     // to any child process. This is usually not necessary and its a good
     // idea to drop them if not needed.
     prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0);
+#endif
 
     meminfo_t m = parse_meminfo();
 


### PR DESCRIPTION
We have some embedded devices that are running an ancient linux kernel thus missing some features added in later kernels.

These are the changes we needed to make to get it to run on those kernels

Probably should have checked the pull requests because they contained the same fixes (in one form or another) but live and learn. 

Not too enthused about storing a pid in a var named pidfd but it was the neatest solution I could think of