### PR TITLE
Adding an option to ignore processes owned by root

### DIFF
--- a/kill.c
+++ b/kill.c
@@ -267,6 +267,19 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
     }
 
     {
+        int res = get_uid(cur->pid);
+        if (res < 0) {
+            debug("pid %d: error reading uid: %s\n", cur->pid, strerror(-res));
+            return false;
+        }
+        cur->uid = res;
+    }
+    if (cur->uid == 0 && args->ignore_root_user) {
+        // Ignore processes owned by root user.
+        return false;
+    }
+
+    {
         int res = get_oom_score(cur->pid);
         if (res < 0) {
             debug("pid %d: error reading oom_score: %s\n", cur->pid, strerror(-res));
@@ -333,14 +346,6 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
             debug("pid %d: error reading process name: %s\n", cur->pid, strerror(-res));
             return false;
         }
-    }
-    {
-        int res = get_uid(cur->pid);
-        if (res < 0) {
-            debug("pid %d: error reading uid: %s\n", cur->pid, strerror(-res));
-            return false;
-        }
-        cur->uid = res;
     }
     return true;
 }

--- a/kill.h
+++ b/kill.h
@@ -20,6 +20,8 @@ typedef struct {
     char* notify_ext;
     /* kill all processes within a process group */
     bool kill_process_group;
+    /* do not kill processes owned by root */
+    bool ignore_root_user;
     /* prefer/avoid killing these processes. NULL = no-op. */
     regex_t* prefer_regex;
     regex_t* avoid_regex;

--- a/main.c
+++ b/main.c
@@ -40,6 +40,7 @@ enum {
     LONG_OPT_AVOID,
     LONG_OPT_DRYRUN,
     LONG_OPT_IGNORE,
+    LONG_OPT_IGNORE_ROOT,
 };
 
 static int set_oom_score_adj(int);
@@ -86,6 +87,7 @@ int main(int argc, char* argv[])
         .mem_kill_percent = 5,
         .swap_kill_percent = 5,
         .report_interval_ms = 1000,
+        .ignore_root_user = false,
         /* omitted fields are set to zero */
     };
     int set_my_priority = 0;
@@ -127,6 +129,7 @@ int main(int argc, char* argv[])
         { "avoid", required_argument, NULL, LONG_OPT_AVOID },
         { "ignore", required_argument, NULL, LONG_OPT_IGNORE },
         { "dryrun", no_argument, NULL, LONG_OPT_DRYRUN },
+        { "ignore-root-user", no_argument, NULL, LONG_OPT_IGNORE_ROOT },
         { "help", no_argument, NULL, 'h' },
         { 0, 0, NULL, 0 } /* end-of-array marker */
     };
@@ -215,6 +218,10 @@ int main(int argc, char* argv[])
         case 'p':
             set_my_priority = 1;
             break;
+        case LONG_OPT_IGNORE_ROOT:
+            args.ignore_root_user = true;
+            fprintf(stderr, "Processes owned by root will not be killed\n");
+            break;
         case LONG_OPT_PREFER:
             prefer_cmds = optarg;
             break;
@@ -251,6 +258,7 @@ int main(int argc, char* argv[])
                 "                            to 0 to disable completely\n"
                 "  -p                        set niceness of earlyoom to -20 and oom_score_adj to\n"
                 "                            -100\n"
+                "  --ignore-root-user        do not kill processes owned by root\n"
                 "  --prefer REGEX            prefer to kill processes matching REGEX\n"
                 "  --avoid REGEX             avoid killing processes matching REGEX\n"
                 "  --ignore REGEX            ignore processes matching REGEX\n"

--- a/testsuite_cli_test.go
+++ b/testsuite_cli_test.go
@@ -101,9 +101,10 @@ func TestCli(t *testing.T) {
 		// We use {"-r=0"} instead of {"-r", "0"} so runEarlyoom() can detect that there will be no output
 		{args: []string{"-r=0"}, code: -1, stderrContains: startupMsg, stdoutEmpty: true},
 		{args: []string{"-r", "0.1"}, code: -1, stderrContains: startupMsg, stdoutContains: memReport},
-		// Test --avoid and --prefer
+		// Test --avoid, --prefer and -ignore-root-user
 		{args: []string{"--avoid", "MyProcess1"}, code: -1, stderrContains: "Will avoid killing", stdoutContains: memReport},
 		{args: []string{"--prefer", "MyProcess2"}, code: -1, stderrContains: "Preferring to kill", stdoutContains: memReport},
+		{args: []string{"--ignore-root-user"}, code: -1, stderrContains: "Processes owned by root will not be killed", stdoutContains: memReport},
 		{args: []string{"-i"}, code: -1, stderrContains: "Option -i is ignored"},
 		// Extra arguments should error out
 		{args: []string{"xyz"}, code: 13, stderrContains: "extra argument not understood", stdoutEmpty: true},


### PR DESCRIPTION
This PR addresses situations where important system operations, like OS upgrades, are interrupted by earlyoom. In environments where majority of workload is generated by user processes, it should be safe to leave root processes out of earlyoom.

Closes #267