### PR TITLE
Let systemd set `Nice` and `OOMScoreAdjust`

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -9,6 +9,10 @@ ExecStart=:TARGET:/earlyoom $EARLYOOM_ARGS
 DynamicUser=true
 # Allow killing processes and calling mlockall()
 AmbientCapabilities=CAP_KILL CAP_IPC_LOCK
+# Give priority to our process
+Nice=-20
+# Avoid getting killed by OOM
+OOMScoreAdjust=-1000
 # We don't need write access anywhere
 ProtectSystem=strict
 # We don't need /home at all, make it inaccessible


### PR DESCRIPTION
Allow one more capability
to avoid warnings on startup (with `-p`):

    Could not set priority: Permission denied. Continuing anyway
    Could not set oom_score_adj: Permission denied. Continuing anyway

I found this issue while using the openSUSE `earlyoom` package that defaults to `-p`.