### PR TITLE
earlyoom.service: redirect stderr and more handening

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -5,24 +5,47 @@ Documentation=man:earlyoom(1) https://github.com/rfjakob/earlyoom
 [Service]
 EnvironmentFile=-:SYSCONFDIR:/default/earlyoom
 ExecStart=:TARGET:/earlyoom $EARLYOOM_ARGS
-# Run as an unprivileged user with random user id
-DynamicUser=true
 # Allow killing processes and calling mlockall()
 AmbientCapabilities=CAP_KILL CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_KILL CAP_IPC_LOCK
 # Give priority to our process
 Nice=-20
 # Avoid getting killed by OOM
 OOMScoreAdjust=-100
-# We don't need write access anywhere
-ProtectSystem=strict
-# We don't need /home at all, make it inaccessible
-ProtectHome=true
 # earlyoom never exits on it's own, so have systemd
 # restart it should it get killed for some reason.
 Restart=always
 # set memory limits and max tasks number
 TasksMax=10
 MemoryMax=50M
+
+# Hardening. Deny everything we don't use.
+
+# Run as an unprivileged user with random user id.
+DynamicUser=true
+# We don't need write access anywhere.
+ProtectSystem=strict
+# We don't need /home at all, make it inaccessible.
+ProtectHome=true
+PrivateDevices=true
+ProtectClock=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+LockPersonality=true
+PrivateNetwork=true
+IPAddressDeny=true
+
+# Unix socket is used by dbus-send.
+RestrictAddressFamilies=AF_UNIX
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@resources @privileged
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
1. Redirect stderr to the journal so that informational messages are not silently lost.
2. Add more hardening options as possible, based on `systemd-analyze security earlyoom.service`. Most of them are copied from [systemd-oomd.service](https://github.com/systemd/systemd/blob/88c6f8f894435c38a075dd268d34f7bcc839dfd2/units/systemd-oomd.service.in).