### PR TITLE
earlyoom.service: add Conflicts

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Early OOM Daemon
 Documentation=man:earlyoom(1) https://github.com/rfjakob/earlyoom
+Conflicts=systemd-oomd.service systemd-oomd.socket nohang.service nohang-desktop.service oomd.service
 
 [Service]
 EnvironmentFile=-:SYSCONFDIR:/default/earlyoom


### PR DESCRIPTION
Some distros default to systemd oom handling. Mark systemd unit conflict with other oom handlers to prevent incompatibility.