### PR TITLE
add --prefer-only option to only kill processes matching --prefer

### DIFF
--- a/kill.c
+++ b/kill.c
@@ -309,11 +309,15 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
             debug("pid %d: error reading process name: %s\n", cur->pid, strerror(-res));
             return false;
         }
-        if (args->prefer_regex && regexec(args->prefer_regex, cur->name, (size_t)0, NULL, 0) == 0) {
-            if (args->sort_by_rss) {
-                cur->VmRSSkiB += VMRSS_PREFER;
-            } else {
-                cur->badness += BADNESS_PREFER;
+        if (args->prefer_regex) {
+            if (regexec(args->prefer_regex, cur->name, (size_t)0, NULL, 0) == 0) {
+                if (args->sort_by_rss) {
+                    cur->VmRSSkiB += VMRSS_PREFER;
+                } else {
+                    cur->badness += BADNESS_PREFER;
+                }
+            } else if (args->prefer_only) {
+                return false;
             }
         }
         if (args->avoid_regex && regexec(args->avoid_regex, cur->name, (size_t)0, NULL, 0) == 0) {

--- a/kill.h
+++ b/kill.h
@@ -33,6 +33,8 @@ typedef struct {
     int report_interval_ms;
     /* Flag --dryrun was passed */
     bool dryrun;
+    /* Flag --prefer-only was passed */
+    bool prefer_only;
 } poll_loop_args_t;
 
 void kill_process(const poll_loop_args_t* args, int sig, const procinfo_t* victim);

--- a/testsuite_cli_test.go
+++ b/testsuite_cli_test.go
@@ -105,6 +105,10 @@ func TestCli(t *testing.T) {
 		// Test --avoid, --prefer, --ignore-root-user and --sort-by-rss
 		{args: []string{"--avoid", "MyProcess1"}, code: -1, stderrContains: "Will avoid killing", stdoutContains: memReport},
 		{args: []string{"--prefer", "MyProcess2"}, code: -1, stderrContains: "Preferring to kill", stdoutContains: memReport},
+		{args: []string{"--prefer", "MyProcess1", "--prefer-only", "--avoid", "MyProcess2"}, code: -1, stderrContains: "prefer-only and --avoid are mutually", stdoutContains: memReport},
+		{args: []string{"--prefer", "MyProcess1", "--prefer-only"}, code: -1, stderrContains: "prefer-only mode enabled", stdoutContains: memReport},
+		{args: []string{"--avoid", "MyProcess2", "--prefer-only"}, code: 22, stderrContains: "fatal", stdoutEmpty: true},
+		{args: []string{"--prefer-only"}, code: 22, stderrContains: "fatal", stdoutEmpty: true},
 		{args: []string{"--ignore-root-user"}, code: -1, stderrContains: "Processes owned by root will not be killed", stdoutContains: memReport},
 		{args: []string{"--sort-by-rss"}, code: -1, stderrContains: "Find process with the largest rss", stdoutContains: memReport},
 		{args: []string{"-i"}, code: -1, stderrContains: "Option -i is ignored"},


### PR DESCRIPTION
While --avoid exists to list processes that should not be killed, it may be desirable to have earlyoom simply ignore any processes that do not match the regex specified in --prefer. It should be noted that the Linux kernel may still opt to kill other processes if earlyoom did not free up enough memory to prevent an oom.