### PR TITLE
Fix systemd service IPAddressDeny parameter value

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -38,7 +38,7 @@ RestrictNamespaces=true
 RestrictRealtime=true
 LockPersonality=true
 PrivateNetwork=true
-IPAddressDeny=true
+IPAddressDeny=any
 
 # Unix socket is used by dbus-send.
 RestrictAddressFamilies=AF_UNIX


### PR DESCRIPTION
I noticed in my system logs that the hardening parameter IPAddressDeny has an incorrect value:

`bal. 18 10:58:40 systemd[1]: /usr/lib/systemd/system/earlyoom.service:41: Invalid address prefix is specified in [Service] IPAddressDeny=, ignoring assignment: true`

It's not a boolean but a list of IP addresses or predefined symbolic names (according to https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html#IPAddressAllow=ADDRESS%5B/PREFIXLENGTH%5D%E2%80%A6).

I set it to `any` which means 0.0.0.0/0 which basically blocks all network access.