### PR TITLE
remove systemd resources syscall filter

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -45,7 +45,7 @@ RestrictAddressFamilies=AF_UNIX
 
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
-SystemCallFilter=~@resources @privileged
+SystemCallFilter=~@privileged
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Not allowing @resources syscalls causes earlyoom to be terminated when launched with the `-p` flag because it tries to set process priority which is part of the @resources set (https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#SystemCallFilter=).

From my system logs:
```
bal. 18 10:40:50 earlyoom[13343]: earlyoom 1.8
bal. 18 10:40:50 earlyoom[13343]: Notifying through D-Bus
bal. 18 10:40:50 earlyoom[13343]: Preferring to kill process names that match regex '(^|/)(java|Isolated Web Co|Web Content|WebExtensions|firefox|chrome|opera|falkon|ffmpeg|vlc|mpv|akregator|thumbnail.so)$'
bal. 18 10:40:50 earlyoom[13343]: Will avoid killing process names that match regex '(^|/)(systemd|Xorg|X|Xwayland|xdm|sddm|kdm|gdm|lightdm|plasmashell|kwin_wayland|kwin_x11|ssh|yast|yast2|y2controlcenter|zypper|rpm|dnf)$'
bal. 18 10:40:50 systemd[1]: Started Process Core Dump (PID 13344/UID 0).
bal. 18 10:40:50 systemd-coredump[13345]: [🡕] Process 13343 (earlyoom) of user 61876 dumped core.
                                        
                                          Stack trace of thread 13343:
                                          #0  0x00007f260bb07b5b setpriority (libc.so.6 + 0x107b5b)
                                          #1  0x000055845a69a161 n/a (earlyoom + 0x3161)
                                          #2  0x00007f260ba2a1f0 __libc_start_call_main (libc.so.6 + 0x2a1f0)
                                          #3  0x00007f260ba2a2b9 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a2b9)
                                          #4  0x000055845a69a3b5 n/a (earlyoom + 0x33b5)
                                          ELF object binary architecture: AMD x86-64
bal. 18 10:40:50 systemd[1]: earlyoom.service: Main process exited, code=dumped, status=31/SYS
bal. 18 10:40:50 systemd[1]: earlyoom.service: Failed with result 'core-dump'.
```

Of course the `-p` flag isn't necessary when earlyoom is launched through systemd where the priority is set but it would be nice if the process wouldn't just be killed like that.