### PR TITLE
Add process_mrelease to allowed system calls

### DIFF
--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -44,7 +44,7 @@ IPAddressDeny=any
 RestrictAddressFamilies=AF_UNIX
 
 SystemCallArchitectures=native
-SystemCallFilter=@system-service
+SystemCallFilter=@system-service process_mrelease
 SystemCallFilter=~@resources @privileged
 
 [Install]


### PR DESCRIPTION
required since 2e004040deb5b30880d72740bd71095e326479de

Without this, earlyoom seems to work but actually is killed with signal SIGSYS whenever an OOM situation occurs. It is immediately restarted by systemd, which is why this problem might go unnoticed.

PS: Thanks for this wonderful tool, it has saved me a thousand times :-)