### PR TITLE
Makefile: hardcode systemd unit installation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
 MAN1DIR ?= $(MANDIR)/man1
-SYSCONFDIR ?= $(PREFIX)/etc
-SYSTEMDUNITDIR ?= $(SYSCONFDIR)/systemd/system
+# Systemd hardcodes its unit path list
+SYSCONFDIR ?= /etc
+SYSTEMDUNITDIR ?= /etc/systemd/system
 PANDOC := $(shell command -v pandoc 2> /dev/null)
 
 .PHONY: all clean install uninstall format test


### PR DESCRIPTION
The path can't be relative to PREFIX.
This is how things work with systemd...

Sources:
- https://github.com/systemd/systemd/issues/19414
- https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html

Closes https://github.com/rfjakob/earlyoom/issues/327