### PR TITLE
Export EARLYOOM_ENVIRON of killed processes along with related info

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -133,6 +133,8 @@ following environment variables:
     EARLYOOM_PID     Process PID
     EARLYOOM_NAME    Process name truncated to 16 bytes (as reported in /proc/PID/comm)
     EARLYOOM_CMDLINE Process cmdline truncated to 256 bytes (as reported in /proc/PID/cmdline)
+    EARLYOOM_ENVIRON Process environment truncated to 65536 bytes (as reported in /proc/PID/environ),
+		     '\0' null characters translated to '\x1E' (ASCII Record Separator)
     EARLYOOM_UID     UID of the user running the process
 
 WARNING: `EARLYOOM_NAME` can contain spaces, newlines, special characters

--- a/earlyoom.service.in
+++ b/earlyoom.service.in
@@ -5,9 +5,9 @@ Documentation=man:earlyoom(1) https://github.com/rfjakob/earlyoom
 [Service]
 EnvironmentFile=-:SYSCONFDIR:/default/earlyoom
 ExecStart=:TARGET:/earlyoom $EARLYOOM_ARGS
-# Allow killing processes and calling mlockall()
-AmbientCapabilities=CAP_KILL CAP_IPC_LOCK
-CapabilityBoundingSet=CAP_KILL CAP_IPC_LOCK
+# Allow killing processes, calling mlockall() and reading /proc/PID/environ
+AmbientCapabilities=CAP_KILL CAP_IPC_LOCK CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_KILL CAP_IPC_LOCK CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
 # Give priority to our process
 Nice=-20
 # Avoid getting killed by OOM
@@ -19,10 +19,11 @@ Restart=always
 TasksMax=10
 MemoryMax=50M
 
+# Cannot run as an unprivileged user with random user id because it needs to read /proc/PID/environ
+DynamicUser=false
+
 # Hardening. Deny everything we don't use.
 
-# Run as an unprivileged user with random user id.
-DynamicUser=true
 # We don't need write access anywhere.
 ProtectSystem=strict
 # We don't need /home at all, make it inaccessible.

--- a/kill.c
+++ b/kill.c
@@ -95,6 +95,7 @@ static void notify_ext(const char* script, const procinfo_t* victim)
     setenv("EARLYOOM_UID", uid_str, 1);
     setenv("EARLYOOM_NAME", victim->name, 1);
     setenv("EARLYOOM_CMDLINE", victim->cmdline, 1);
+    setenv("EARLYOOM_ENVIRON", victim->environ, 1);
 
     execl(script, script, NULL);
     warn("%s: exec %s failed: %s\n", __func__, script, strerror(errno));
@@ -405,6 +406,12 @@ void fill_informative_fields(procinfo_t* cur)
         int res = get_cmdline(cur->pid, cur->cmdline, sizeof(cur->cmdline));
         if (res < 0) {
             debug("%s: pid %d: error reading process cmdline: %s\n", __func__, cur->pid, strerror(-res));
+        }
+    }
+    if (strlen(cur->environ) == 0) {
+        int res = get_environ(cur->pid, cur->environ, sizeof(cur->environ));
+        if (res < 0) {
+            warn("%s: pid %d: error reading process environ: %s\n", __func__, cur->pid, strerror(-res));
         }
     }
     if (cur->uid == PROCINFO_FIELD_NOT_SET) {

--- a/meminfo.h
+++ b/meminfo.h
@@ -3,6 +3,7 @@
 #define MEMINFO_H
 
 #define PATH_LEN 256
+#define ENVIRON_LEN 65536
 
 #include "proc_pid.h"
 #include <stdbool.h>
@@ -32,6 +33,7 @@ typedef struct procinfo {
     pid_stat_t stat;
     char name[PATH_LEN];
     char cmdline[PATH_LEN];
+    char environ[ENVIRON_LEN];
 } procinfo_t;
 
 // placeholder value for numeric fields
@@ -45,5 +47,6 @@ int get_oom_score_adj(const int pid, int* out);
 int get_comm(int pid, char* out, size_t outlen);
 int get_uid(int pid);
 int get_cmdline(int pid, char* out, size_t outlen);
+int get_environ(int pid, char* out, size_t outlen);
 
 #endif


### PR DESCRIPTION
With this change, along with info such as cmdline, PID, UID and so on, extra information (its environment variables) will be available to allow to identify the process being killed due to memory overuse.

This is not captured by the existing methods, and it can be useful to identify processes which are invoked in the same generic way and whose runtime behavior or the data that it processes changes depending on the environment at the time of launch, or that simply by looking at the content of the variables in its environment gives extra info about a single process from others using the same binary.

This can be used in combination with -N to run a script with info about the process just killed, and use the information on the desired environment variables to log/notify about the problem.