### PR TITLE
Implement -P to invoke a program as pre-hook before killing a process

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -125,7 +125,7 @@ To actually see the notifications in your GUI session, you need to have
 running as your user.
 
 #### -N /PATH/TO/SCRIPT
-Run the given script for each process killed. Must be an absolute path.
+Run the given script for each process killed, afterwards. Must be an absolute path.
 
 Within the script, information about the killed process can be obtained via the
 following environment variables:
@@ -138,6 +138,20 @@ following environment variables:
 WARNING: `EARLYOOM_NAME` can contain spaces, newlines, special characters
 and is controlled by the user, or it can be empty! Make sure that your
 notification script can handle that!
+
+#### -P /PATH/TO/SCRIPT
+Run the given script for each process killed, beforehand. Must be an absolute path.
+
+See `-N`, it behaves in the same way except being run before the process is killed.
+
+Note that there is a small delay (200 milliseconds) in killing the chosen victim
+to give some room for this program to be spawned and do something meaningful.
+The invoked program has to be very fast to gather information from the running
+process before it gets killed.
+
+Any such delay, and the extra resources taken by the spawned process, always
+take some toll and further stress the already stressed system.  Therefore, the
+invoked process should be as lean and fast as possible.
 
 #### -g
 Kill all processes that have same process group id (PGID) as the process

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ running as your user.
 
 Additionally, earlyoom can execute a script for each process killed, providing
 information about the process via the `EARLYOOM_PID`, `EARLYOOM_UID` and
-`EARLYOOM_NAME` environment variables. Pass `-N /path/to/script` to enable.
+`EARLYOOM_NAME` environment variables. Pass `-N /path/to/script` to enable
+after the process is killed, or `-P /path/to/script` to be invoked before.
 
 Warning: In case of dryrun mode, the script will be executed in rapid
 succession, ensure you have some sort of rate-limit implemented.
@@ -241,6 +242,7 @@ Usage: ./earlyoom [OPTION]...
   -S SIZE[,KILL_SIZE]       set free swap minimum to SIZE KiB
   -n                        enable d-bus notifications
   -N /PATH/TO/SCRIPT        call script after oom kill
+  -P /PATH/TO/SCRIPT        call script before oom kill
   -g                        kill all processes within a process group
   -d, --debug               enable debugging messages
   -v                        print version information and exit

--- a/kill.h
+++ b/kill.h
@@ -16,8 +16,10 @@ typedef struct {
     double swap_kill_percent;
     /* send d-bus notifications? */
     bool notify;
-    /* Path to script for programmatic notifications (or NULL) */
+    /* Path to script for programmatic notifications after killing (or NULL) */
     char* notify_ext;
+    /* Path to script/binary for to execute before killing (or NULL) */
+    char* kill_process_prehook;
     /* kill all processes within a process group */
     bool kill_process_group;
     /* do not kill processes owned by root */

--- a/main.c
+++ b/main.c
@@ -79,6 +79,14 @@ static void startup_selftests(poll_loop_args_t* args)
             warn("%s: -N: notify script '%s' is not executable: %s\n", __func__, args->notify_ext, strerror(errno));
         }
     }
+    if (args->kill_process_prehook) {
+        if (args->kill_process_prehook[0] != '/') {
+            warn("%s: -P: pre-hook program '%s' is not an absolute path, disabling -P\n", __func__, args->kill_process_prehook);
+            args->kill_process_prehook = NULL;
+        } else if (access(args->kill_process_prehook, X_OK)) {
+            warn("%s: -P: pre-hook program '%s' is not executable: %s\n", __func__, args->kill_process_prehook, strerror(errno));
+        }
+    }
 
 #ifdef PROFILE_FIND_LARGEST_PROCESS
     struct timespec t0 = { 0 }, t1 = { 0 };
@@ -147,7 +155,7 @@ int main(int argc, char* argv[])
     meminfo_t m = parse_meminfo();
 
     int c;
-    const char* short_opt = "m:s:M:S:kingN:dvr:ph";
+    const char* short_opt = "m:s:M:S:kingN:P:dvr:ph";
     struct option long_opt[] = {
         { "prefer", required_argument, NULL, LONG_OPT_PREFER },
         { "avoid", required_argument, NULL, LONG_OPT_AVOID },
@@ -228,6 +236,9 @@ int main(int argc, char* argv[])
             break;
         case 'N':
             args.notify_ext = optarg;
+            break;
+        case 'P':
+            args.kill_process_prehook = optarg;
             break;
         case 'd':
             enable_debug = 1;


### PR DESCRIPTION
This implements an option to invoke an external program, analog to the existing "-N" (which runs a program after killing a process), but being executed before sending signals to the process, with purposes such as gathering some specific info of the running process.