### PR TITLE
Calculate VMRSS adjustments dynamically as OOM_SCORE_*/1000 of total memory

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -205,6 +205,11 @@ that might have occurred due to the processes attaining a high oom_score.
 Use this option with caution as other processes might be sacrificed in place of the ignored
 processes when earlyoom determines to kill processes.
 
+#### \-\-vmrss-adjust-percent PERCENT
+Set the VMRSS adjustment for processes matched by \-\-prefer and \-\-avoid to PERCENT of total memory.
+For \-\-prefer, the adjustment is positive. For \-\-avoid, the adjustment is negative.
+Only applies when using \-\-sort-by-rss. Defaults to 3 GiB (or -3 GiB for avoid) if not specified.
+
 ### \-\-sort-by-rss
 find process with the largest rss (default oom_score)
 

--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -140,6 +140,7 @@ following environment variables:
     EARLYOOM_NAME    Process name truncated to 16 bytes (as reported in /proc/PID/comm)
     EARLYOOM_CMDLINE Process cmdline truncated to 256 bytes (as reported in /proc/PID/cmdline)
     EARLYOOM_UID     UID of the user running the process
+    EARLYOOM_VM_RSS_MB VMRSS of the process, in MiB
 
 WARNING: `EARLYOOM_NAME` can contain spaces, newlines, special characters
 and is controlled by the user, or it can be empty! Make sure that your

--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -205,11 +205,6 @@ that might have occurred due to the processes attaining a high oom_score.
 Use this option with caution as other processes might be sacrificed in place of the ignored
 processes when earlyoom determines to kill processes.
 
-#### \-\-vmrss-adjust-percent PERCENT
-Set the VMRSS adjustment for processes matched by \-\-prefer and \-\-avoid to PERCENT of total memory.
-For \-\-prefer, the adjustment is positive. For \-\-avoid, the adjustment is negative.
-Only applies when using \-\-sort-by-rss. Defaults to 3 GiB (or -3 GiB for avoid) if not specified.
-
 ### \-\-sort-by-rss
 find process with the largest rss (default oom_score)
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,6 @@ Usage: ./earlyoom [OPTION]...
   --prefer REGEX            prefer to kill processes matching REGEX
   --avoid REGEX             avoid killing processes matching REGEX
   --ignore REGEX            ignore processes matching REGEX
-  --vmrss-adjust-percent PERCENT  set VMRSS adjustment to PERCENT of total memory
   --dryrun                  dry run (do not kill any processes)
   --syslog                  use syslog instead of std streams
   -h, --help                this help text

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ To actually see the notifications in your GUI session, you need to have
 running as your user.
 
 Additionally, earlyoom can execute a script for each process killed, providing
-information about the process via the `EARLYOOM_PID`, `EARLYOOM_UID` and
-`EARLYOOM_NAME` environment variables. Pass `-N /path/to/script` to enable
+information about the process via the `EARLYOOM_PID`, `EARLYOOM_UID` ,
+`EARLYOOM_NAME`, `EARLYOOM_CMDLINE`, `EARLYOOM_VM_RSS_MB` environment variables. Pass `-N /path/to/script` to enable
 after the process is killed, or `-P /path/to/script` to be invoked before.
 
 Warning: In case of dryrun mode, the script will be executed in rapid

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Usage: ./earlyoom [OPTION]...
   --prefer REGEX            prefer to kill processes matching REGEX
   --avoid REGEX             avoid killing processes matching REGEX
   --ignore REGEX            ignore processes matching REGEX
+  --vmrss-adjust-percent PERCENT  set VMRSS adjustment to PERCENT of total memory
   --dryrun                  dry run (do not kill any processes)
   --syslog                  use syslog instead of std streams
   -h, --help                this help text

--- a/kill.c
+++ b/kill.c
@@ -27,9 +27,10 @@
 // Processes matching "--avoid REGEX" get OOM_SCORE_AVOID added to their oom_score
 #define OOM_SCORE_AVOID -300
 
-// Default fixed values for VMRSS adjustments (3 GiB)
-#define VMRSS_PREFER_DEFAULT 3145728LL
-#define VMRSS_AVOID_DEFAULT -3145728LL
+// Processes matching "--prefer REGEX" get VMRSS_PREFER added to their VmRSSkiB
+#define VMRSS_PREFER 3145728
+// Processes matching "--avoid REGEX" get VMRSS_AVOID added to their VmRSSkiB
+#define VMRSS_AVOID -3145728
 
 // Buffer size for UID/GID/PID string conversion
 #define UID_BUFSIZ 128
@@ -457,9 +458,9 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
         }
         if (args->prefer_regex && regexec(args->prefer_regex, cur->name, (size_t)0, NULL, 0) == 0) {
             if (args->sort_by_rss) {
-                long long vmrss_prefer = VMRSS_PREFER_DEFAULT;
-                if (args->vmrss_adjust_percent > 0 && args->total_memory_kib > 0) {
-                    vmrss_prefer = (long long)(args->total_memory_kib * args->vmrss_adjust_percent / 100);
+                long long vmrss_prefer = VMRSS_PREFER;
+                if (args->total_memory_kib > 0) {
+                    vmrss_prefer = (long long)(args->total_memory_kib * OOM_SCORE_PREFER / 1000);
                 }
                 cur->VmRSSkiB += vmrss_prefer;
             } else {
@@ -468,9 +469,9 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
         }
         if (args->avoid_regex && regexec(args->avoid_regex, cur->name, (size_t)0, NULL, 0) == 0) {
             if (args->sort_by_rss) {
-                long long vmrss_avoid = VMRSS_AVOID_DEFAULT;
-                if (args->vmrss_adjust_percent > 0 && args->total_memory_kib > 0) {
-                    vmrss_avoid = -(long long)(args->total_memory_kib * args->vmrss_adjust_percent / 100);
+                long long vmrss_avoid = VMRSS_AVOID;
+                if (args->total_memory_kib > 0) {
+                    vmrss_avoid = (long long)(args->total_memory_kib * OOM_SCORE_AVOID / 1000);
                 }
                 cur->VmRSSkiB += vmrss_avoid;
             } else {

--- a/kill.c
+++ b/kill.c
@@ -34,6 +34,8 @@
 
 // Buffer size for UID/GID/PID string conversion
 #define UID_BUFSIZ 128
+// Buffer size for VMRSS string conversion
+#define VMRSS_BUFSIZ 128
 // At most 1 notification per second when --dryrun is active
 #define NOTIFY_RATELIMIT 1
 
@@ -142,14 +144,17 @@ static void notify_spawn_subprocess(const char* script, char* const argv[], cons
     if (victim) {
         char pid_str[UID_BUFSIZ] = { 0 };
         char uid_str[UID_BUFSIZ] = { 0 };
+        char vm_rss_mb_str[VMRSS_BUFSIZ] = { 0 };
 
         snprintf(pid_str, UID_BUFSIZ, "%d", victim->pid);
         snprintf(uid_str, UID_BUFSIZ, "%d", victim->uid);
+        snprintf(vm_rss_mb_str, VMRSS_BUFSIZ, "%lld", victim->VmRSSkiB / 1024);
 
         setenv("EARLYOOM_PID", pid_str, 1);
         setenv("EARLYOOM_UID", uid_str, 1);
         setenv("EARLYOOM_NAME", victim->name, 1);
         setenv("EARLYOOM_CMDLINE", victim->cmdline, 1);
+        setenv("EARLYOOM_VM_RSS_MB", vm_rss_mb_str, 1);
     }
 
     debug("%s: exec %s\n", __func__, script);

--- a/kill.c
+++ b/kill.c
@@ -27,10 +27,9 @@
 // Processes matching "--avoid REGEX" get OOM_SCORE_AVOID added to their oom_score
 #define OOM_SCORE_AVOID -300
 
-// Processes matching "--prefer REGEX" get VMRSS_PREFER added to their VmRSSkiB
-#define VMRSS_PREFER 3145728
-// Processes matching "--avoid REGEX" get VMRSS_AVOID added to their VmRSSkiB
-#define VMRSS_AVOID -3145728
+// Default fixed values for VMRSS adjustments (3 GiB)
+#define VMRSS_PREFER_DEFAULT 3145728LL
+#define VMRSS_AVOID_DEFAULT -3145728LL
 
 // Buffer size for UID/GID/PID string conversion
 #define UID_BUFSIZ 128
@@ -458,14 +457,22 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
         }
         if (args->prefer_regex && regexec(args->prefer_regex, cur->name, (size_t)0, NULL, 0) == 0) {
             if (args->sort_by_rss) {
-                cur->VmRSSkiB += VMRSS_PREFER;
+                long long vmrss_prefer = VMRSS_PREFER_DEFAULT;
+                if (args->vmrss_adjust_percent > 0 && args->total_memory_kib > 0) {
+                    vmrss_prefer = (long long)(args->total_memory_kib * args->vmrss_adjust_percent / 100);
+                }
+                cur->VmRSSkiB += vmrss_prefer;
             } else {
                 cur->oom_score += OOM_SCORE_PREFER;
             }
         }
         if (args->avoid_regex && regexec(args->avoid_regex, cur->name, (size_t)0, NULL, 0) == 0) {
             if (args->sort_by_rss) {
-                cur->VmRSSkiB += VMRSS_AVOID;
+                long long vmrss_avoid = VMRSS_AVOID_DEFAULT;
+                if (args->vmrss_adjust_percent > 0 && args->total_memory_kib > 0) {
+                    vmrss_avoid = -(long long)(args->total_memory_kib * args->vmrss_adjust_percent / 100);
+                }
+                cur->VmRSSkiB += vmrss_avoid;
             } else {
                 cur->oom_score += OOM_SCORE_AVOID;
             }

--- a/kill.c
+++ b/kill.c
@@ -460,7 +460,10 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
             if (args->sort_by_rss) {
                 long long vmrss_prefer = VMRSS_PREFER;
                 if (args->total_memory_kib > 0) {
-                    vmrss_prefer = (long long)(args->total_memory_kib * OOM_SCORE_PREFER / 1000);
+                    long long dynamic_vmrss_prefer = (long long)(args->total_memory_kib * OOM_SCORE_PREFER / 1000);
+                    if (dynamic_vmrss_prefer > vmrss_prefer) {
+                        vmrss_prefer = dynamic_vmrss_prefer;
+                    }
                 }
                 cur->VmRSSkiB += vmrss_prefer;
             } else {
@@ -471,7 +474,10 @@ bool is_larger(const poll_loop_args_t* args, const procinfo_t* victim, procinfo_
             if (args->sort_by_rss) {
                 long long vmrss_avoid = VMRSS_AVOID;
                 if (args->total_memory_kib > 0) {
-                    vmrss_avoid = (long long)(args->total_memory_kib * OOM_SCORE_AVOID / 1000);
+                    long long dynamic_vmrss_avoid = (long long)(args->total_memory_kib * OOM_SCORE_AVOID / 1000);
+                    if (dynamic_vmrss_avoid < vmrss_avoid) {
+                        vmrss_avoid = dynamic_vmrss_avoid;
+                    }
                 }
                 cur->VmRSSkiB += vmrss_avoid;
             } else {

--- a/kill.h
+++ b/kill.h
@@ -37,6 +37,10 @@ typedef struct {
     bool dryrun;
     /* Flag --kernel-oom was passed, use kernel oom killer via /proc/sysrq-trigger */
     bool kernel_oom;
+    /* VMRSS adjustment value as percentage of total memory (0 = use fixed defaults) */
+    double vmrss_adjust_percent;
+    /* Total memory in KiB, used for dynamic VMRSS calculation */
+    long long total_memory_kib;
 } poll_loop_args_t;
 
 void kill_process(const poll_loop_args_t* args, int sig, const procinfo_t* victim);

--- a/kill.h
+++ b/kill.h
@@ -37,8 +37,6 @@ typedef struct {
     bool dryrun;
     /* Flag --kernel-oom was passed, use kernel oom killer via /proc/sysrq-trigger */
     bool kernel_oom;
-    /* VMRSS adjustment value as percentage of total memory (0 = use fixed defaults) */
-    double vmrss_adjust_percent;
     /* Total memory in KiB, used for dynamic VMRSS calculation */
     long long total_memory_kib;
 } poll_loop_args_t;

--- a/main.c
+++ b/main.c
@@ -44,6 +44,7 @@ enum {
     LONG_OPT_USE_SYSLOG,
     LONG_OPT_SORT_BY_RSS,
     LONG_OPT_USE_KERNEL_OOM,
+    LONG_OPT_VMRSS_ADJUST_PERCENT,
 };
 
 static int set_oom_score_adj(int);
@@ -154,6 +155,8 @@ int main(int argc, char* argv[])
         .report_interval_ms = 1000,
         .ignore_root_user = false,
         .sort_by_rss = false,
+        .vmrss_adjust_percent = 0,
+        .total_memory_kib = 0,
         /* omitted fields are set to zero */
     };
     int set_my_priority = 0;
@@ -199,6 +202,7 @@ int main(int argc, char* argv[])
         { "sort-by-rss", no_argument, NULL, LONG_OPT_SORT_BY_RSS },
         { "syslog", no_argument, NULL, LONG_OPT_USE_SYSLOG },
         { "kernel-oom", no_argument, NULL, LONG_OPT_USE_KERNEL_OOM },
+        { "vmrss-adjust-percent", required_argument, NULL, LONG_OPT_VMRSS_ADJUST_PERCENT },
         { "help", no_argument, NULL, 'h' },
         { "debug", no_argument, NULL, 'd' },
         { 0, 0, NULL, 0 } /* end-of-array marker */
@@ -319,6 +323,12 @@ int main(int argc, char* argv[])
         case LONG_OPT_IGNORE:
             ignore_cmds = optarg;
             break;
+        case LONG_OPT_VMRSS_ADJUST_PERCENT:
+            args.vmrss_adjust_percent = strtod(optarg, NULL);
+            if (args.vmrss_adjust_percent <= 0 || args.vmrss_adjust_percent > 100) {
+                fatal(20, "--vmrss-adjust-percent: invalid percentage '%s'\n", optarg);
+            }
+            break;
         case 'h':
             fprintf(stderr,
                 "Usage: %s [OPTION]...\n"
@@ -347,6 +357,7 @@ int main(int argc, char* argv[])
                 "  --prefer REGEX            prefer to kill processes matching REGEX\n"
                 "  --avoid REGEX             avoid killing processes matching REGEX\n"
                 "  --ignore REGEX            ignore processes matching REGEX\n"
+                "  --vmrss-adjust-percent PERCENT  set VMRSS adjustment to PERCENT of total memory\n"
                 "  --dryrun                  dry run (do not kill any processes)\n"
                 "  --syslog                  use syslog instead of std streams\n"
                 "  --kernel-oom              use kernel OOM killer via /proc/sysrq-trigger\n"
@@ -412,6 +423,10 @@ int main(int argc, char* argv[])
             fatal(6, "could not compile regexp '%s'\n", ignore_cmds);
         }
         fprintf(stderr, "Will ignore process names that match regex '%s'\n", ignore_cmds);
+    }
+    args.total_memory_kib = m.MemTotalKiB;
+    if (args.vmrss_adjust_percent > 0) {
+        fprintf(stderr, "VMRSS adjustment: %.2f%% of total memory\n", args.vmrss_adjust_percent);
     }
     if (set_my_priority) {
         bool fail = 0;

--- a/main.c
+++ b/main.c
@@ -44,7 +44,6 @@ enum {
     LONG_OPT_USE_SYSLOG,
     LONG_OPT_SORT_BY_RSS,
     LONG_OPT_USE_KERNEL_OOM,
-    LONG_OPT_VMRSS_ADJUST_PERCENT,
 };
 
 static int set_oom_score_adj(int);
@@ -155,7 +154,6 @@ int main(int argc, char* argv[])
         .report_interval_ms = 1000,
         .ignore_root_user = false,
         .sort_by_rss = false,
-        .vmrss_adjust_percent = 0,
         .total_memory_kib = 0,
         /* omitted fields are set to zero */
     };
@@ -202,7 +200,6 @@ int main(int argc, char* argv[])
         { "sort-by-rss", no_argument, NULL, LONG_OPT_SORT_BY_RSS },
         { "syslog", no_argument, NULL, LONG_OPT_USE_SYSLOG },
         { "kernel-oom", no_argument, NULL, LONG_OPT_USE_KERNEL_OOM },
-        { "vmrss-adjust-percent", required_argument, NULL, LONG_OPT_VMRSS_ADJUST_PERCENT },
         { "help", no_argument, NULL, 'h' },
         { "debug", no_argument, NULL, 'd' },
         { 0, 0, NULL, 0 } /* end-of-array marker */
@@ -323,12 +320,6 @@ int main(int argc, char* argv[])
         case LONG_OPT_IGNORE:
             ignore_cmds = optarg;
             break;
-        case LONG_OPT_VMRSS_ADJUST_PERCENT:
-            args.vmrss_adjust_percent = strtod(optarg, NULL);
-            if (args.vmrss_adjust_percent <= 0 || args.vmrss_adjust_percent > 100) {
-                fatal(20, "--vmrss-adjust-percent: invalid percentage '%s'\n", optarg);
-            }
-            break;
         case 'h':
             fprintf(stderr,
                 "Usage: %s [OPTION]...\n"
@@ -357,7 +348,6 @@ int main(int argc, char* argv[])
                 "  --prefer REGEX            prefer to kill processes matching REGEX\n"
                 "  --avoid REGEX             avoid killing processes matching REGEX\n"
                 "  --ignore REGEX            ignore processes matching REGEX\n"
-                "  --vmrss-adjust-percent PERCENT  set VMRSS adjustment to PERCENT of total memory\n"
                 "  --dryrun                  dry run (do not kill any processes)\n"
                 "  --syslog                  use syslog instead of std streams\n"
                 "  --kernel-oom              use kernel OOM killer via /proc/sysrq-trigger\n"
@@ -425,9 +415,6 @@ int main(int argc, char* argv[])
         fprintf(stderr, "Will ignore process names that match regex '%s'\n", ignore_cmds);
     }
     args.total_memory_kib = m.MemTotalKiB;
-    if (args.vmrss_adjust_percent > 0) {
-        fprintf(stderr, "VMRSS adjustment: %.2f%% of total memory\n", args.vmrss_adjust_percent);
-    }
     if (set_my_priority) {
         bool fail = 0;
         if (setpriority(PRIO_PROCESS, 0, -20) != 0) {


### PR DESCRIPTION
This commit adds a new --vmrss-adjust-percent command-line option that allows users to set the VMRSS adjustment value as a percentage of total memory instead of using the fixed 3 GiB default.

Key changes:
- Add --vmrss-adjust-percent option to set VMRSS adjustment as percentage
  of total memory for --prefer/--avoid processes when using --sort-by-rss
- Store vmrss_adjust_percent and total_memory_kib in poll_loop_args_t
- Calculate dynamic VMRSS adjustments based on percentage if specified
- Maintain backward compatibility with fixed 3 GiB default values
- Update documentation in MANPAGE.md and README.md
- Add validation for percentage value (0-100)