### PR TITLE
New argument --kill-wait controls maximum time earlyoom waits for a killed process to exit (continues #366): fix TestCli/--kill-wait_100000

### DIFF
--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -123,6 +123,12 @@ When earlyoom is run through its default systemd service, the `-p` switch doesn'
     OOMScoreAdjust=-100
     Nice=-20
 
+#### --kill-wait SECONDS
+Set the maximum time (in seconds) to wait for a process to die after being
+sent a kill signal (default: 10). Some processes may take longer than the
+default 10 seconds to terminate. Increase this value if you see warnings
+about processes not exiting in time.
+
 #### -n
 Enable notifications via d-bus.
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Usage: ./earlyoom [OPTION]...
                             to 0 to disable completely
   -p                        set niceness of earlyoom to -20 and oom_score_adj to
                             -100
+  --kill-wait SECONDS       max seconds to wait for a process to die (default 10)
   --ignore-root-user        do not kill processes owned by root
   --sort-by-rss             find process with the largest rss (default oom_score)
   --prefer REGEX            prefer to kill processes matching REGEX

--- a/kill.c
+++ b/kill.c
@@ -310,11 +310,12 @@ int kill_release(const pid_t pid, const int pidfd, const int sig)
 
 /*
  * Send the selected signal to "pid" and wait for the process to exit
- * (max 10 seconds)
+ * (max kill_wait_timeout_secs)
  */
 int kill_wait(const poll_loop_args_t* args, pid_t pid, int sig)
 {
     const unsigned poll_ms = 100;
+    const unsigned max_poll_iterations = (unsigned)((unsigned)args->kill_wait_timeout_secs * 1000u / poll_ms);
     int pidfd = -1;
 
     if (args->dryrun && sig != 0) {
@@ -352,7 +353,7 @@ int kill_wait(const poll_loop_args_t* args, pid_t pid, int sig)
     struct timespec t0 = { 0 };
     clock_gettime(CLOCK_MONOTONIC, &t0);
 
-    for (unsigned i = 0; i < 100; i++) {
+    for (unsigned i = 0; i < max_poll_iterations; i++) {
         struct timespec t1 = { 0 };
         clock_gettime(CLOCK_MONOTONIC, &t1);
         float secs = (float)(t1.tv_sec - t0.tv_sec) + (float)(t1.tv_nsec - t0.tv_nsec) / (float)1e9;

--- a/kill.h
+++ b/kill.h
@@ -33,6 +33,8 @@ typedef struct {
     regex_t* ignore_regex;
     /* memory report interval, in milliseconds */
     int report_interval_ms;
+    /* kill_wait timeout in seconds (default 10) */
+    int kill_wait_timeout_secs;
     /* Flag --dryrun was passed */
     bool dryrun;
     /* Flag --kernel-oom was passed, use kernel oom killer via /proc/sysrq-trigger */

--- a/main.c
+++ b/main.c
@@ -33,9 +33,6 @@
 #define VERSION "*** unknown version ***"
 #endif
 
-// Maximum kill_wait timeout in seconds (24 hours)
-#define MAX_KILL_WAIT_TIMEOUT 86400
-
 /* Arbitrary identifiers for long options that do not have a short
  * version */
 enum {
@@ -194,7 +191,7 @@ int main(int argc, char* argv[])
     meminfo_t m = parse_meminfo();
 
     int c;
-    const char* short_opt = "m:s:M:S:kingN:P:dvr:phw:";
+    const char* short_opt = "m:s:M:S:kingN:P:dvr:ph";
     struct option long_opt[] = {
         { "prefer", required_argument, NULL, LONG_OPT_PREFER },
         { "avoid", required_argument, NULL, LONG_OPT_AVOID },

--- a/main.c
+++ b/main.c
@@ -33,6 +33,9 @@
 #define VERSION "*** unknown version ***"
 #endif
 
+// Maximum kill_wait timeout in seconds (24 hours)
+#define MAX_KILL_WAIT_TIMEOUT 86400
+
 /* Arbitrary identifiers for long options that do not have a short
  * version */
 enum {
@@ -293,8 +296,8 @@ int main(int argc, char* argv[])
             break;
         case LONG_OPT_KILL_WAIT_TIMEOUT: {
             int timeout_secs = atoi(optarg);
-            if (timeout_secs <= 0) {
-                fatal(14, "kill-wait-timeout: invalid timeout '%s' (must be > 0)\n", optarg);
+            if (timeout_secs <= 0 || timeout_secs > MAX_KILL_WAIT_TIMEOUT) {
+                fatal(14, "kill-wait-timeout: invalid timeout '%s' (must be > 0 and <= %d)\n", optarg, MAX_KILL_WAIT_TIMEOUT);
             }
             args.kill_wait_timeout_secs = timeout_secs;
             break;

--- a/testsuite_cli_test.go
+++ b/testsuite_cli_test.go
@@ -143,6 +143,13 @@ func TestCli(t *testing.T) {
 		// Test --use-kernel-oom option
 		{args: []string{"--kernel-oom"}, code: -1, stderrContains: "Using kernel OOM killer", stdoutContains: memReport},
 		{args: []string{"--kernel-oom", "--dryrun"}, code: -1, stderrContains: "dryrun", stdoutContains: memReport},
+		// Test --kill-wait flags
+		{args: []string{"--kill-wait", "20"}, code: -1, stderrContains: startupMsg, stdoutContains: memReport},
+		{args: []string{"--kill-wait", "15"}, code: -1, stderrContains: startupMsg, stdoutContains: memReport},
+		{args: []string{"--kill-wait", "0"}, code: 14, stderrContains: "fatal", stdoutEmpty: true},
+		{args: []string{"--kill-wait", "-1"}, code: 14, stderrContains: "fatal", stdoutEmpty: true},
+		{args: []string{"--kill-wait", "100000"}, code: 14, stderrContains: "fatal", stdoutEmpty: true},
+		{args: []string{"--kill-wait", "abc"}, code: 14, stderrContains: "fatal", stdoutEmpty: true},
 	}
 	if swapTotal > 0 {
 		// Tests that cannot work when there is no swap enabled


### PR DESCRIPTION
This PR continues the work from #366  by @iandennismiller. I have synced with the latest upstream and fixed [--- FAIL: TestCli/--kill-wait_100000 (0.00s)]. Closes #366.